### PR TITLE
Add Excel upload to verified part markings

### DIFF
--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -21,6 +21,10 @@
         <label>Verified Markings <input type="text" name="verified_markings"></label><br>
         <button type="submit">Add</button>
       </form>
+      <form method="post" enctype="multipart/form-data" style="margin-top:20px;">
+        <label>Excel File <input type="file" name="excel_file" accept=".xlsx,.xls" required></label><br>
+        <button type="submit">Upload</button>
+      </form>
     </div>
     <div id="divider"></div>
     <div id="markings-table">


### PR DESCRIPTION
## Summary
- Allow uploading Excel spreadsheets to bulk insert verified part markings
- Add upload form to part markings page

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689a292145ec8325b601a0d47a1d611b