### PR TITLE
Enable manual date override for AOI report uploads

### DIFF
--- a/run.py
+++ b/run.py
@@ -133,6 +133,12 @@ def aoi_report():
     conn = get_db()
     if request.method == 'POST' and 'excel_file' in request.files:
         file = request.files['excel_file']
+        manual_date = request.form.get('report_date')
+        if manual_date:
+            try:
+                manual_date = datetime.strptime(manual_date, '%Y-%m-%d').date().isoformat()
+            except ValueError:
+                manual_date = None
         if file and file.filename:
             filename = file.filename
             save_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
@@ -151,13 +157,16 @@ def aoi_report():
                     if m:
                         shift = m.group(1)
                         date_str = m.group(2)
-                        try:
-                            report_date = datetime.strptime(date_str, '%m/%d/%y').date().isoformat()
-                        except ValueError:
-                            report_date = date_str
+                        if manual_date:
+                            report_date = manual_date
+                        else:
+                            try:
+                                report_date = datetime.strptime(date_str, '%m/%d/%y').date().isoformat()
+                            except ValueError:
+                                report_date = date_str
                     else:
                         shift = ''
-                        report_date = ''
+                        report_date = manual_date or ''
                     i += 1
                     # move to header row
                     while i < len(df) and str(df.iloc[i,0]) != 'Operator':

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
+  <a href="/">← Home</a>
   <h1>AOI Daily Report</h1>
   <p>
     <a href="/aoi">View Reports</a> |
@@ -13,17 +14,33 @@
   </p>
 
   {% if upload %}
-    <form method="post" enctype="multipart/form-data">
-      <label for="excel_file">Excel File:</label>
-      <input type="file" id="excel_file" name="excel_file" accept=".xls,.xlsx">
-      <button type="submit">Upload</button>
-    </form>
+    <div class="action-panel">
+      <div class="action-card">
+        <h2>Upload Daily Report</h2>
+        <p class="desc">Choose the AOI report file and optionally set the report date.</p>
+        <form method="post" enctype="multipart/form-data">
+          <label>Report Date
+            <input type="date" name="report_date">
+          </label><br>
+          <label>Excel File
+            <input type="file" name="excel_file" accept=".xls,.xlsx" required>
+          </label><br>
+          <p class="field-desc">If left blank, the date from the file will be used.</p>
+          <button type="submit">Upload</button>
+        </form>
+      </div>
+    </div>
   {% else %}
-    <form method="get" action="/aoi">
-      <label for="date">Select Date:</label>
-      <input type="date" id="date" name="date" value="{{ selected_date }}">
-      <button type="submit">View</button>
-    </form>
+    <div class="action-panel">
+      <div class="action-card">
+        <h2>View Daily Report</h2>
+        <form method="get" action="/aoi">
+          <label for="date">Select Date</label>
+          <input type="date" id="date" name="date" value="{{ selected_date }}">
+          <button type="submit">View</button>
+        </form>
+      </div>
+    </div>
     {% if selected_date %}
       {% if data %}
         {% for shift, rows in data.items() %}


### PR DESCRIPTION
## Summary
- Allow AOI daily report uploads to specify a manual report date
- Refresh AOI upload/view templates with action cards and home navigation

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689a357d678c83259d90a33008e561d2