### PR TITLE
Preserve AOI report formatting and restrict data range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 pandas
 openpyxl
 xlrd
+xlsx2html

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -42,7 +42,9 @@
       </div>
     </div>
     {% if selected_date %}
-      {% if data %}
+      {% if html_exists %}
+        <iframe src="{{ url_for('aoi_html', filename=selected_date + '.html') }}" width="100%" height="600"></iframe>
+      {% elif data %}
         {% for shift, rows in data.items() %}
           <h2>{{ shift }} Shift</h2>
           <table>


### PR DESCRIPTION
## Summary
- Limit AOI Excel parsing to columns A–F and track report date
- Convert uploaded AOI reports to HTML for styled viewing and serve via new route
- Display formatted report through iframe and add xlsx2html dependency

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement xlsx2html)*
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689a3864fce88325b327f04954854460