### PR TITLE
Add NG control chart and threshold lines

### DIFF
--- a/run.py
+++ b/run.py
@@ -295,8 +295,10 @@ def chart_data():
     start = request.args.get('start')
     end = request.args.get('end')
     threshold = request.args.get('threshold', type=int, default=0)
+    metric = request.args.get('metric', 'fc')
+    column = 'falsecall_parts' if metric == 'fc' else 'ng_parts'
     conn = get_db()
-    query = 'SELECT model_name, SUM(falsecall_parts)*1.0/SUM(total_boards) AS rate FROM moat WHERE 1=1'
+    query = f'SELECT model_name, SUM({column})*1.0/SUM(total_boards) AS rate FROM moat WHERE 1=1'
     params = []
     if start:
         query += ' AND upload_time >= ?'

--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -24,8 +24,41 @@ window.addEventListener('DOMContentLoaded', () => {
       settings.style.display = settings.style.display === 'none' ? 'block' : 'none';
     });
   }
+  const ngChartBtn = document.getElementById('control-chart-ng-btn');
+  const ngSettings = document.getElementById('chart-ng-settings');
+  if (ngChartBtn && ngSettings) {
+    ngChartBtn.addEventListener('click', () => {
+      ngSettings.style.display = ngSettings.style.display === 'none' ? 'block' : 'none';
+    });
+  }
 
-  // Chart modal logic
+  // Threshold plugin for horizontal lines
+  const thresholdPlugin = {
+    id: 'thresholdPlugin',
+    afterDraw: (chart, args, options) => {
+      const {ctx, chartArea: {left, right}, scales: {y}} = chart;
+      ctx.save();
+      if (options.red) {
+        const yPos = y.getPixelForValue(options.red.value);
+        ctx.strokeStyle = options.red.color;
+        ctx.beginPath();
+        ctx.moveTo(left, yPos);
+        ctx.lineTo(right, yPos);
+        ctx.stroke();
+      }
+      if (options.yellow) {
+        const yPos = y.getPixelForValue(options.yellow.value);
+        ctx.strokeStyle = options.yellow.color;
+        ctx.beginPath();
+        ctx.moveTo(left, yPos);
+        ctx.lineTo(right, yPos);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+  };
+
+  // FC Chart modal logic
   const runBtn = document.getElementById('run-chart-btn');
   const chartModal = document.getElementById('chart-modal');
   const closeChart = document.getElementById('close-chart-modal');
@@ -38,7 +71,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const end = document.getElementById('end-date').value;
       const yMax = parseFloat(document.getElementById('y-max').value) || 1;
       const threshold = parseInt(document.getElementById('min-boards').value) || 0;
-      fetch(`/analysis/chart-data?start=${start}&end=${end}&threshold=${threshold}`)
+      fetch(`/analysis/chart-data?start=${start}&end=${end}&threshold=${threshold}&metric=fc`)
         .then(res => res.json())
         .then(data => {
           const labels = data.map(d => d.model);
@@ -47,13 +80,56 @@ window.addEventListener('DOMContentLoaded', () => {
           chartInstance = new Chart(ctx, {
             type: 'bar',
             data: { labels, datasets: [{ label: 'FalseCall Rate', data: values }] },
-            options: { scales: { y: { beginAtZero: true, max: yMax } } }
+            options: {
+              scales: { y: { beginAtZero: true, max: yMax } },
+              plugins: { thresholdPlugin: { red: {value:20, color:'red'}, yellow: {value:10, color:'yellow'} } }
+            },
+            plugins: [thresholdPlugin]
           });
+          const dateText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
+          document.getElementById('fc-chart-date-range').textContent = dateText;
           chartModal.style.display = 'block';
         });
     });
     closeChart.addEventListener('click', () => { chartModal.style.display = 'none'; });
     window.addEventListener('click', e => { if (e.target === chartModal) chartModal.style.display = 'none'; });
+  }
+
+  // NG Chart modal logic
+  const runNgBtn = document.getElementById('run-ng-chart-btn');
+  const chartNgModal = document.getElementById('chart-ng-modal');
+  const closeNgChart = document.getElementById('close-chart-ng-modal');
+  const ngCtx = document.getElementById('chart-ng-canvas');
+  let ngChartInstance;
+
+  if (runNgBtn && chartNgModal && closeNgChart && ngCtx) {
+    runNgBtn.addEventListener('click', () => {
+      const start = document.getElementById('ng-start-date').value;
+      const end = document.getElementById('ng-end-date').value;
+      const yMax = parseFloat(document.getElementById('ng-y-max').value) || 1;
+      const threshold = parseInt(document.getElementById('ng-min-boards').value) || 0;
+      fetch(`/analysis/chart-data?start=${start}&end=${end}&threshold=${threshold}&metric=ng`)
+        .then(res => res.json())
+        .then(data => {
+          const labels = data.map(d => d.model);
+          const values = data.map(d => d.rate);
+          if (ngChartInstance) ngChartInstance.destroy();
+          ngChartInstance = new Chart(ngCtx, {
+            type: 'bar',
+            data: { labels, datasets: [{ label: 'NG Rate', data: values }] },
+            options: {
+              scales: { y: { beginAtZero: true, max: yMax } },
+              plugins: { thresholdPlugin: { red: {value:0.1, color:'red'} } }
+            },
+            plugins: [thresholdPlugin]
+          });
+          const dateText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
+          document.getElementById('ng-chart-date-range').textContent = dateText;
+          chartNgModal.style.display = 'block';
+        });
+    });
+    closeNgChart.addEventListener('click', () => { chartNgModal.style.display = 'none'; });
+    window.addEventListener('click', e => { if (e.target === chartNgModal) chartNgModal.style.display = 'none'; });
   }
 
   // Uploads modal logic (unchanged)

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -55,6 +55,27 @@
               <button id="run-chart-btn" title="Generate control chart">Run Chart</button>
             </div>
           </div>
+          <div class="action-card">
+            <h2>Control Chart - Avg NGs</h2>
+            <p class="desc">Configure options and generate an NG rate control chart.</p>
+            <button id="control-chart-ng-btn" title="Show or hide chart options">Control Chart Settings</button>
+            <div id="chart-ng-settings" style="display:none; margin-top:10px;">
+              <label>Start Date
+                <input type="date" id="ng-start-date" title="Start date for data range">
+              </label><br>
+              <label>End Date
+                <input type="date" id="ng-end-date" title="End date for data range">
+              </label><br>
+              <label>Y Max
+                <input type="number" id="ng-y-max" value="1" step="0.01" title="Maximum value for Y-axis">
+              </label><br>
+              <label>Min Boards
+                <input type="number" id="ng-min-boards" value="7" title="Minimum boards required">
+              </label><br>
+              <p class="field-desc">Generate the chart using the selected parameters.</p>
+              <button id="run-ng-chart-btn" title="Generate NG control chart">Run Chart</button>
+            </div>
+          </div>
         </div>
       </div>
       <div id="divider"></div>
@@ -98,7 +119,17 @@
       <div class="modal-content">
         <span id="close-chart-modal" class="close">&times;</span>
         <h2>Control Chart - Avg FalseCall Rate</h2>
+        <p id="fc-chart-date-range"></p>
         <canvas id="chart-canvas" height="200"></canvas>
+      </div>
+    </div>
+
+    <div id="chart-ng-modal" class="modal">
+      <div class="modal-content">
+        <span id="close-chart-ng-modal" class="close">&times;</span>
+        <h2>Control Chart - Avg NG Rate</h2>
+        <p id="ng-chart-date-range"></p>
+        <canvas id="chart-ng-canvas" height="200"></canvas>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- add metric parameter to chart data endpoint to fetch false call or NG rates
- extend analysis page with NG control chart controls and date range display
- render threshold lines and date range on FC and NG charts

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689a558d90108325a63587a9e31ac8f5