### PR TITLE
Set control chart PDFs to landscape and add job previews

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template, request, redirect, url_for, jsonify, s
 import os
 import sqlite3
 import pandas as pd
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 from xlsx2html import xlsx2html
 
@@ -76,7 +76,31 @@ init_db()
 # --- Routes ---
 @app.route('/')
 def home():
-    return render_template('home.html')
+    # Example placeholder data; replace with SAP integration later
+    jobs = []
+    today = datetime.today()
+    example_data = [
+        {
+            'job': 'JOB123',
+            'due_in_days': 5,
+            'locations': [('Hand Assembly', 295), ('Rework', 5)],
+        },
+        {
+            'job': 'JOB456',
+            'due_in_days': 10,
+            'locations': [('Hand Assembly', 100)],
+        },
+    ]
+    for item in example_data:
+        due_date = today + timedelta(days=item['due_in_days'])
+        jobs.append({
+            'job': item['job'],
+            'due_date': due_date.strftime('%Y-%m-%d'),
+            'due_in': f"{item['due_in_days']} days",
+            'locations': item['locations'],
+            'total': sum(count for _, count in item['locations'])
+        })
+    return render_template('home.html', sample_jobs=jobs)
 
 @app.route('/part-markings', methods=['GET', 'POST'])
 def part_markings():

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -15,6 +15,12 @@ h1, p { color: #333; }
 }
 .widget:hover { background:#f9f9f9; }
 
+/* Job preview section */
+.job-previews { margin-bottom: 20px; }
+.job-preview { margin-bottom: 10px; }
+.job-preview ul { list-style: none; padding-left: 0; margin: 5px 0 0 0; }
+.job-preview li { font-family: monospace; }
+
 /* MOAT stats text */
 .moat-stats {
   font-size: 0.9em;

--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -89,7 +89,8 @@ window.addEventListener('DOMContentLoaded', () => {
                 pointBackgroundColor: 'black',
                 pointBorderColor: 'black',
                 fill: false,
-                tension: 0
+                tension: 0,
+                borderWidth: 1
               }]
             },
             options: {
@@ -111,7 +112,7 @@ window.addEventListener('DOMContentLoaded', () => {
     downloadFcBtn.addEventListener('click', () => {
       if (!chartInstance) return;
       const { jsPDF } = window.jspdf;
-      const pdf = new jsPDF();
+      const pdf = new jsPDF({ orientation: 'landscape' });
       pdf.text('Control Chart - Avg FalseCall Rate', 10, 10);
       const dateText = document.getElementById('fc-chart-date-range').textContent;
       pdf.text(dateText, 10, 20);
@@ -155,7 +156,8 @@ window.addEventListener('DOMContentLoaded', () => {
                 pointBackgroundColor: 'black',
                 pointBorderColor: 'black',
                 fill: false,
-                tension: 0
+                tension: 0,
+                borderWidth: 1
               }]
             },
             options: {
@@ -177,7 +179,7 @@ window.addEventListener('DOMContentLoaded', () => {
     downloadNgBtn.addEventListener('click', () => {
       if (!ngChartInstance) return;
       const { jsPDF } = window.jspdf;
-      const pdf = new jsPDF();
+      const pdf = new jsPDF({ orientation: 'landscape' });
       pdf.text('Control Chart - Avg NG Rate', 10, 10);
       const dateText = document.getElementById('ng-chart-date-range').textContent;
       pdf.text(dateText, 10, 20);

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,6 +7,20 @@
 </head>
 <body>
   <h1>Welcome to SPCApp</h1>
+  <div class="job-previews">
+    <h2>Floor Jobs Preview</h2>
+    {% for job in sample_jobs %}
+      <div class="job-preview">
+        <strong>{{ job.job }} – due {{ job.due_date }} ({{ job.due_in }})</strong>
+        <ul>
+          {% for loc, count in job.locations %}
+            <li>{{ loc }}....{{ count }}</li>
+          {% endfor %}
+          <li>Total: {{ job.total }}</li>
+        </ul>
+      </div>
+    {% endfor %}
+  </div>
   <p>Select a section below:</p>
   <div class="widgets">
     <div class="widget" onclick="location.href='/jobs'">


### PR DESCRIPTION
## Summary
- Render control chart PDFs in landscape orientation and use thinner connecting lines for better readability
- Add example floor job previews on the home page ahead of eventual SAP data integration
- Style job preview section for clarity

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689a61ca95ac8325b9bcf87d6f233c3f