### PR TITLE
Handle outliers in control charts

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -76,26 +76,54 @@ window.addEventListener('DOMContentLoaded', () => {
         .then(res => res.json())
         .then(data => {
           const labels = data.map(d => d.model);
-          const values = data.map(d => d.rate);
+          const inRangeValues = data.map(d => (d.rate <= yMax ? d.rate : null));
+          const outliers = data.filter(d => d.rate > yMax);
           if (chartInstance) chartInstance.destroy();
           chartInstance = new Chart(ctx, {
             type: 'line',
             data: {
               labels,
-              datasets: [{
-                label: 'FalseCall Rate',
-                data: values,
-                borderColor: 'black',
-                pointBackgroundColor: 'black',
-                pointBorderColor: 'black',
-                fill: false,
-                tension: 0,
-                borderWidth: 1
-              }]
+              datasets: [
+                {
+                  label: 'FalseCall Rate',
+                  data: inRangeValues,
+                  borderColor: 'black',
+                  pointBackgroundColor: 'black',
+                  pointBorderColor: 'black',
+                  fill: false,
+                  tension: 0,
+                  borderWidth: 1,
+                  clip: false
+                },
+                {
+                  label: 'Outliers',
+                  data: outliers.map(d => ({ x: d.model, y: yMax, real: d.rate })),
+                  borderColor: 'red',
+                  pointBackgroundColor: 'red',
+                  pointBorderColor: 'red',
+                  showLine: false,
+                  pointStyle: 'triangle',
+                  rotation: 180,
+                  clip: false
+                }
+              ]
             },
             options: {
+              layout: { padding: { top: 20 } },
               scales: { y: { beginAtZero: true, max: yMax } },
-              plugins: { thresholdPlugin: { red: {value:20, color:'red'}, yellow: {value:10, color:'yellow'} } }
+              plugins: {
+                thresholdPlugin: { red: { value: 20, color: 'red' }, yellow: { value: 10, color: 'yellow' } },
+                tooltip: {
+                  callbacks: {
+                    label: ctx => {
+                      if (ctx.dataset.label === 'Outliers') {
+                        return `${ctx.label}: ${ctx.raw.real}`;
+                      }
+                      return `${ctx.dataset.label}: ${ctx.parsed.y}`;
+                    }
+                  }
+                }
+              }
             },
             plugins: [thresholdPlugin]
           });
@@ -143,26 +171,54 @@ window.addEventListener('DOMContentLoaded', () => {
         .then(res => res.json())
         .then(data => {
           const labels = data.map(d => d.model);
-          const values = data.map(d => d.rate);
+          const inRangeValues = data.map(d => (d.rate <= yMax ? d.rate : null));
+          const outliers = data.filter(d => d.rate > yMax);
           if (ngChartInstance) ngChartInstance.destroy();
           ngChartInstance = new Chart(ngCtx, {
             type: 'line',
             data: {
               labels,
-              datasets: [{
-                label: 'NG Rate',
-                data: values,
-                borderColor: 'black',
-                pointBackgroundColor: 'black',
-                pointBorderColor: 'black',
-                fill: false,
-                tension: 0,
-                borderWidth: 1
-              }]
+              datasets: [
+                {
+                  label: 'NG Rate',
+                  data: inRangeValues,
+                  borderColor: 'black',
+                  pointBackgroundColor: 'black',
+                  pointBorderColor: 'black',
+                  fill: false,
+                  tension: 0,
+                  borderWidth: 1,
+                  clip: false
+                },
+                {
+                  label: 'Outliers',
+                  data: outliers.map(d => ({ x: d.model, y: yMax, real: d.rate })),
+                  borderColor: 'red',
+                  pointBackgroundColor: 'red',
+                  pointBorderColor: 'red',
+                  showLine: false,
+                  pointStyle: 'triangle',
+                  rotation: 180,
+                  clip: false
+                }
+              ]
             },
             options: {
+              layout: { padding: { top: 20 } },
               scales: { y: { beginAtZero: true, max: yMax } },
-              plugins: { thresholdPlugin: { red: {value:0.1, color:'red'} } }
+              plugins: {
+                thresholdPlugin: { red: { value: 0.1, color: 'red' } },
+                tooltip: {
+                  callbacks: {
+                    label: ctx => {
+                      if (ctx.dataset.label === 'Outliers') {
+                        return `${ctx.label}: ${ctx.raw.real}`;
+                      }
+                      return `${ctx.dataset.label}: ${ctx.parsed.y}`;
+                    }
+                  }
+                }
+              }
             },
             plugins: [thresholdPlugin]
           });


### PR DESCRIPTION
## Summary
- Split chart data into in-range points and outliers in analysis and popup scripts
- Render outlier markers above the chart using a dedicated dataset with custom tooltip
- Allow markers outside plot area by disabling clipping and adding top padding

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a66af462c8325b1a70ada4976fe7b