### PR TITLE
Sort home page job preview by due date with color-coded urgency

### DIFF
--- a/run.py
+++ b/run.py
@@ -77,7 +77,6 @@ init_db()
 @app.route('/')
 def home():
     # Example placeholder data; replace with SAP integration later
-    jobs = []
     today = datetime.today()
     example_data = [
         {
@@ -91,14 +90,30 @@ def home():
             'locations': [('Hand Assembly', 100)],
         },
     ]
+
+    # Sort by days until due so earliest jobs appear first
+    example_data.sort(key=lambda x: x['due_in_days'])
+
+    jobs = []
     for item in example_data:
         due_date = today + timedelta(days=item['due_in_days'])
+
+        days = item['due_in_days']
+        if days <= 2:
+            highlight = 'danger'
+        elif days <= 6:
+            highlight = 'warning'
+        else:
+            highlight = ''
+
         jobs.append({
             'job': item['job'],
             'due_date': due_date.strftime('%Y-%m-%d'),
-            'due_in': f"{item['due_in_days']} days",
+            'due_in': f"{days} days",
             'locations': item['locations'],
-            'total': sum(count for _, count in item['locations'])
+            'total': sum(count for _, count in item['locations']),
+            'highlight': highlight,
+            'due_in_days': days,
         })
     return render_template('home.html', sample_jobs=jobs)
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,8 +16,11 @@ h1, p { color: #333; }
 .widget:hover { background:#f9f9f9; }
 
 /* Job preview section */
-.job-previews { margin-bottom: 20px; }
-.job-preview { margin-bottom: 10px; }
+.job-previews { margin: 0 -20px 20px -20px; width: calc(100% + 40px); }
+.job-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; width: 100%; }
+.job-preview { margin-bottom: 0; padding: 10px; border: 1px solid #ccc; border-radius: 4px; }
+.job-preview.warning { background: #fff3cd; }
+.job-preview.danger { background: #f8d7da; }
 .job-preview ul { list-style: none; padding-left: 0; margin: 5px 0 0 0; }
 .job-preview li { font-family: monospace; }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -9,17 +9,19 @@
   <h1>Welcome to SPCApp</h1>
   <div class="job-previews">
     <h2>Floor Jobs Preview</h2>
-    {% for job in sample_jobs %}
-      <div class="job-preview">
-        <strong>{{ job.job }} – due {{ job.due_date }} ({{ job.due_in }})</strong>
-        <ul>
-          {% for loc, count in job.locations %}
-            <li>{{ loc }}....{{ count }}</li>
-          {% endfor %}
-          <li>Total: {{ job.total }}</li>
-        </ul>
-      </div>
-    {% endfor %}
+    <div class="job-grid">
+      {% for job in sample_jobs %}
+        <div class="job-preview {{ job.highlight }}">
+          <strong>{{ job.job }} – due {{ job.due_date }} ({{ job.due_in }})</strong>
+          <ul>
+            {% for loc, count in job.locations %}
+              <li>{{ loc }}....{{ count }}</li>
+            {% endfor %}
+            <li>Total: {{ job.total }}</li>
+          </ul>
+        </div>
+      {% endfor %}
+    </div>
   </div>
   <p>Select a section below:</p>
   <div class="widgets">


### PR DESCRIPTION
## Summary
- Sort sample job list on the home page by days until due
- Lay out job previews in a full-width six-column grid
- Highlight near-due jobs in red or yellow based on remaining days

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7b1eb6f48325b8cad73fa0783883