### PR TITLE
Add user login and permission controls

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3,6 +3,15 @@ body {
   margin: 20px;
 }
 h1, p { color: #333; }
+.topbar {
+  text-align: right;
+  color: #888;
+  font-size: 0.8em;
+}
+.topbar a {
+  margin-left: 10px;
+  color: #888;
+}
 .widgets { display: flex; gap: 20px; margin-top: 20px; }
 .widget {
   flex:1;

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -1,15 +1,12 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Data Analysis - PPM MOAT & Control Chart</title>
-  <link rel="stylesheet" href="/static/css/style.css">
+{% extends 'base.html' %}
+{% block title %}Data Analysis - PPM MOAT & Control Chart{% endblock %}
+{% block head_extra %}
   <!-- Chart.js for control chart rendering -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="/static/js/analysis.js" defer></script>
-</head>
-<body>
+{% endblock %}
+{% block content %}
   <a href="/">← Home</a>
   <h1>Data Analysis - PPM MOAT</h1>
   {% if not show_moat %}
@@ -18,13 +15,16 @@
     <div class="moat-stats">
       {% if total_rows %}
         Total rows: {{ total_rows }} | Table range: {{ earliest }} - {{ latest }}
+        {% if current_user == 'ADMIN' or permissions['analysis'] %}
         &nbsp;|&nbsp;
         <button id="show-uploads-btn" title="View or delete previously uploaded reports">Manage Uploads</button>
+        {% endif %}
       {% endif %}
     </div>
     <div id="container">
       <div id="analysis-actions">
         <div class="action-panel">
+          {% if current_user == 'ADMIN' or permissions['analysis'] %}
           <div class="action-card">
             <h2>Upload PPM Report</h2>
             <p class="desc">Import a PPM report (.xls or .xlsx) to analyze false call rates.</p>
@@ -35,6 +35,7 @@
               <button type="submit" title="Upload and analyze the report">Upload Report</button>
             </form>
           </div>
+          {% endif %}
           <div class="action-card">
             <h2>Control Chart - Avg FCs</h2>
             <p class="desc">Configure options and generate a false call rate control chart.</p>
@@ -210,5 +211,4 @@
       </div>
     </div>
   {% endif %}
-</body>
-</html>
+{% endblock %}

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -1,19 +1,17 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>AOI Daily Report</title>
-  <link rel="stylesheet" href="/static/css/style.css">
-</head>
-<body>
+{% extends 'base.html' %}
+{% block title %}AOI Daily Report{% endblock %}
+{% block content %}
   <a href="/">← Home</a>
   <h1>AOI Daily Report</h1>
   <p>
-    <a href="/aoi">View Reports</a> |
-    <a href="/aoi?view=upload">Upload Report</a>
+    <a href="/aoi">View Reports</a>
+    {% if current_user == 'ADMIN' or permissions['aoi'] %}
+      | <a href="/aoi?view=upload">Upload Report</a>
+    {% endif %}
   </p>
 
   {% if upload %}
+    {% if current_user == 'ADMIN' or permissions['aoi'] %}
     <div class="action-panel">
       <div class="action-card">
         <h2>Upload Daily Report</h2>
@@ -30,6 +28,9 @@
         </form>
       </div>
     </div>
+    {% else %}
+      <p>Not authorized.</p>
+    {% endif %}
   {% else %}
     <div class="action-panel">
       <div class="action-card">
@@ -73,5 +74,4 @@
       {% endif %}
     {% endif %}
   {% endif %}
-</body>
-</html>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{% block title %}SPCApp{% endblock %}</title>
+  <link rel="stylesheet" href="/static/css/style.css">
+  {% block head_extra %}{% endblock %}
+</head>
+<body>
+  <div class="topbar">
+    <span class="user-label">user:{{ current_user }}</span>
+    <a href="{{ url_for('logout') }}">Logout</a>
+    {% if current_user == 'ADMIN' %}
+      <a href="{{ url_for('settings') }}">Settings</a>
+    {% endif %}
+  </div>
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -1,13 +1,10 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Control Chart</title>
+{% extends 'base.html' %}
+{% block title %}Control Chart{% endblock %}
+{% block head_extra %}
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   <script src="/static/js/chart-popup.js" defer></script>
-</head>
-<body>
+{% endblock %}
+{% block content %}
   <h1>Control Chart – Average FalseCall Rate</h1>
   <canvas id="popup-chart" height="200"></canvas>
-</body>
-</html>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,12 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>SPCApp Home</title>
-  <link rel="stylesheet" href="/static/css/style.css">
-</head>
-<body>
+{% extends 'base.html' %}
+{% block title %}SPCApp Home{% endblock %}
+{% block content %}
   <h1>Welcome to SPCApp</h1>
+  <button onclick="location.href='{{ url_for('logout') }}'">Logout</button>
   <div class="job-previews">
     <h2>Floor Jobs Preview</h2>
     <div class="job-grid">
@@ -46,5 +42,4 @@
       <p>Statistical Controls</p>
     </div>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/jobs.html
+++ b/templates/jobs.html
@@ -1,12 +1,7 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Jobs Dashboard</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
-<body>
-  <a href="{{ url_for('main_views.home') }}">← Home</a>
+{% extends 'base.html' %}
+{% block title %}Jobs Dashboard{% endblock %}
+{% block content %}
+  <a href="/">← Home</a>
   <h1>Jobs Dashboard</h1>
 
   <form id="add-form">
@@ -34,5 +29,4 @@
   </form>
 
   <script src="{{ url_for('static', filename='js/jobs.js') }}"></script>
-</body>
-</html>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+  <h1>Login</h1>
+  <form method="post">
+    <label>User Type
+      <select name="role">
+        <option value="ADMIN">ADMIN</option>
+        <option value="USER">USER</option>
+      </select>
+    </label><br>
+    <label>Password
+      <input type="password" name="password" required>
+    </label><br>
+    <button type="submit">Login</button>
+    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+  </form>
+</body>
+</html>

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -1,12 +1,9 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Verified Part Markings</title>
-  <link rel="stylesheet" href="/static/css/style.css">
+{% extends 'base.html' %}
+{% block title %}Verified Part Markings{% endblock %}
+{% block head_extra %}
   <script src="/static/js/part_markings.js" defer></script>
-</head>
-<body>
+{% endblock %}
+{% block content %}
   <a href="/">← Home</a>
   <h1>Verified Part Markings</h1>
   <div id="container">
@@ -20,6 +17,7 @@
           <p class="field-desc">Highlight matching part number in the table.</p>
           <button id="search-btn" type="button" title="Highlight matching part number">Search</button>
         </div>
+        {% if current_user == 'ADMIN' or permissions['part_markings'] %}
         <div class="action-card">
           <h2>Add New Entry</h2>
           <p class="desc">Use this form to add a single verified part marking.</p>
@@ -54,6 +52,7 @@
             <button type="submit" title="Upload spreadsheet">Upload</button>
           </form>
         </div>
+        {% endif %}
       </div>
     </div>
     <div id="divider"></div>
@@ -82,5 +81,4 @@
       </table>
     </div>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Settings{% endblock %}
+{% block content %}
+  <h1>Settings</h1>
+  <h2>Permissions</h2>
+  <form method="post">
+    <label><input type="checkbox" name="permissions" value="part_markings" {% if permissions['part_markings'] %}checked{% endif %}> Part Markings Upload/Input</label><br>
+    <label><input type="checkbox" name="permissions" value="aoi" {% if permissions['aoi'] %}checked{% endif %}> AOI Report Upload</label><br>
+    <label><input type="checkbox" name="permissions" value="analysis" {% if permissions['analysis'] %}checked{% endif %}> PPM Report Upload</label><br>
+    <button type="submit">Save</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add session-based login for ADMIN and USER accounts with persistent permissions
- Display active user, logout, and settings links in new base template
- Restrict upload and input features based on admin-configured permissions

## Testing
- `python -m py_compile run.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a881ce2108325acac438968f32c17