### PR TITLE
Add dark mode toggle and home navigation buttons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -12,6 +12,10 @@ h1, p { color: #333; }
   margin-left: 10px;
   color: #888;
 }
+.topbar button {
+  margin-left: 10px;
+  font-size: 0.8em;
+}
 .widgets { display: flex; gap: 20px; margin-top: 20px; }
 .widget {
   flex:1;
@@ -122,7 +126,9 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
 .action-card input[type="text"],
 .action-card input[type="number"],
 .action-card input[type="date"],
-.action-card input[type="file"] {
+.action-card input[type="file"],
+.action-card input[type="password"],
+.action-card select {
   width: 100%;
   padding: 6px;
   margin-top: 4px;
@@ -162,3 +168,25 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
   text-align: right;
   font-weight: bold;
 }
+
+/* Dark mode styles */
+body.dark-mode {
+  background: #121212;
+  color: #e0e0e0;
+}
+body.dark-mode h1,
+body.dark-mode p,
+body.dark-mode label,
+body.dark-mode span,
+body.dark-mode a {
+  color: #e0e0e0;
+}
+body.dark-mode .topbar { color: #bbb; }
+body.dark-mode .topbar a { color: #bbb; }
+body.dark-mode .widget { border-color: #555; }
+body.dark-mode .widget:hover { background: #1e1e1e; }
+body.dark-mode .action-card { background: #1e1e1e; border-color: #444; }
+body.dark-mode .action-card p { color: #ccc; }
+body.dark-mode table { border-color: #555; }
+body.dark-mode th,
+body.dark-mode td { border-color: #555; }

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') {
+    document.body.classList.add('dark-mode');
+    toggle.textContent = 'Light Mode';
+  }
+  toggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const isDark = document.body.classList.contains('dark-mode');
+    toggle.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,16 +4,20 @@
   <meta charset="UTF-8">
   <title>{% block title %}SPCApp{% endblock %}</title>
   <link rel="stylesheet" href="/static/css/style.css">
+  <script src="/static/js/theme.js" defer></script>
   {% block head_extra %}{% endblock %}
 </head>
 <body>
+  {% if current_user %}
   <div class="topbar">
     <span class="user-label">user:{{ current_user }}</span>
     <a href="{{ url_for('logout') }}">Logout</a>
+    <button id="theme-toggle" type="button">Dark Mode</button>
     {% if current_user == 'ADMIN' %}
       <a href="{{ url_for('settings') }}">Settings</a>
     {% endif %}
   </div>
+  {% endif %}
   {% block content %}{% endblock %}
 </body>
 </html>

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -5,6 +5,7 @@
   <script src="/static/js/chart-popup.js" defer></script>
 {% endblock %}
 {% block content %}
+  <a href="/">← Home</a>
   <h1>Control Chart – Average FalseCall Rate</h1>
   <canvas id="popup-chart" height="200"></canvas>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,24 +1,22 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Login</title>
-  <link rel="stylesheet" href="/static/css/style.css">
-</head>
-<body>
-  <h1>Login</h1>
-  <form method="post">
-    <label>User Type
-      <select name="role">
-        <option value="ADMIN">ADMIN</option>
-        <option value="USER">USER</option>
-      </select>
-    </label><br>
-    <label>Password
-      <input type="password" name="password" required>
-    </label><br>
-    <button type="submit">Login</button>
-    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
-  </form>
-</body>
-</html>
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+  <div class="action-panel" style="max-width:300px;margin:100px auto;">
+    <div class="action-card">
+      <h1>Login</h1>
+      <form method="post">
+        <label>User Type
+          <select name="role">
+            <option value="ADMIN">ADMIN</option>
+            <option value="USER">USER</option>
+          </select>
+        </label><br>
+        <label>Password
+          <input type="password" name="password" required>
+        </label><br>
+        <button type="submit">Login</button>
+        {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Settings{% endblock %}
 {% block content %}
+  <a href="/">← Home</a>
   <h1>Settings</h1>
   <h2>Permissions</h2>
   <form method="post">


### PR DESCRIPTION
## Summary
- Style login page with base layout and action-card
- Add dark/light mode toggle in topbar with persistence
- Provide Home navigation links on remaining tabs

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689a91b0ee5483258d83a6e18fd3d503