### PR TITLE
Refine dark mode job preview colors

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -190,5 +190,5 @@ body.dark-mode .action-card p { color: #ccc; }
 body.dark-mode table { border-color: #555; }
 body.dark-mode th,
 body.dark-mode td { border-color: #555; }
-body.dark-mode .job-preview.warning { background: #b8860b; color: #fff; }
-body.dark-mode .job-preview.danger { background: #8b0000; color: #fff; }
+body.dark-mode .job-preview.warning { background: #b7b700; border-color: #b7b700; color: #fff; }
+body.dark-mode .job-preview.danger { background: #660000; border-color: #660000; color: #fff; }


### PR DESCRIPTION
## Summary
- Deepen dark-mode danger card to #660000 with matching border
- Shift dark-mode warning card to a brighter yellow tone #b7b700 and set border

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a9ae3d3a48325aaee58e10c5f09be