### PR TITLE
Add AOI dashboard with operator and assembly summaries

### DIFF
--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -1,0 +1,29 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const dataEl = document.getElementById('operator-data');
+  if (dataEl) {
+    const ops = JSON.parse(dataEl.textContent);
+    const ctx = document.getElementById('operatorsChart');
+    if (ctx && ops.length) {
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: ops.map(o => o.operator),
+          datasets: [{
+            label: 'Inspected',
+            data: ops.map(o => o.inspected),
+            backgroundColor: 'rgba(54, 162, 235, 0.7)'
+          }]
+        },
+        options: {
+          scales: {
+            y: { beginAtZero: true }
+          }
+        }
+      });
+    }
+  }
+  if (window.jQuery) {
+    $('#assemblyTable').DataTable();
+  }
+});
+

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -7,6 +7,7 @@
     <a href="/aoi">View Reports</a>
     {% if current_user == 'ADMIN' or permissions['aoi'] %}
       | <a href="/aoi?view=upload">Upload Report</a>
+      | <a href="{{ url_for('aoi_dashboard') }}">Dashboard</a>
     {% endif %}
   </p>
 

--- a/templates/aoi_dashboard.html
+++ b/templates/aoi_dashboard.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block title %}AOI Dashboard{% endblock %}
+{% block head_extra %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" defer></script>
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
+  <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js" defer></script>
+  <script id="operator-data" type="application/json">{{ operators|tojson }}</script>
+  <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
+{% endblock %}
+{% block content %}
+  <a href="{{ url_for('aoi_report') }}">← AOI</a>
+  <h1>AOI Dashboard</h1>
+  <h2>Top Operators by Inspected Quantity</h2>
+  <canvas id="operatorsChart"></canvas>
+  <h2>Assembly Performance</h2>
+  <table id="assemblyTable">
+    <thead>
+      <tr>
+        <th>Assembly</th>
+        <th>Inspected</th>
+        <th>Rejected</th>
+        <th>Yield</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in assemblies %}
+      <tr>
+        <td>{{ row['assembly'] }}</td>
+        <td>{{ row['inspected'] }}</td>
+        <td>{{ row['rejected'] }}</td>
+        <td>{{ '{:.2%}'.format(row['yield']) }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add `/aoi/dashboard` route to aggregate operator and assembly inspection data
- show dashboard with Chart.js bar chart and DataTables table
- link AOI dashboard from AOI reports page for users with permission

## Testing
- `python -m py_compile run.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b1eb9cd9c8325af08afa7ded67235