### PR TITLE
Enhance AOI dashboard with time-series metrics and filters

### DIFF
--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -1,9 +1,13 @@
 window.addEventListener('DOMContentLoaded', () => {
-  const dataEl = document.getElementById('operator-data');
-  if (dataEl) {
-    const ops = JSON.parse(dataEl.textContent);
+  const getData = id => {
+    const el = document.getElementById(id);
+    return el ? JSON.parse(el.textContent) : null;
+  };
+
+  const ops = getData('operator-data');
+  if (ops && ops.length) {
     const ctx = document.getElementById('operatorsChart');
-    if (ctx && ops.length) {
+    if (ctx) {
       new Chart(ctx, {
         type: 'bar',
         data: {
@@ -22,6 +26,69 @@ window.addEventListener('DOMContentLoaded', () => {
       });
     }
   }
+
+  const shiftData = getData('shift-data');
+  if (shiftData && shiftData.length) {
+    const ctx = document.getElementById('shiftChart');
+    if (ctx) {
+      const dates = [...new Set(shiftData.map(r => r.report_date))];
+      const shifts = [...new Set(shiftData.map(r => r.shift))];
+      const colors = ['rgba(255, 99, 132, 0.7)', 'rgba(54, 162, 235, 0.7)', 'rgba(75, 192, 192, 0.7)', 'rgba(255, 205, 86, 0.7)'];
+      const datasets = shifts.map((s, idx) => ({
+        label: s,
+        data: dates.map(d => {
+          const row = shiftData.find(r => r.report_date === d && r.shift === s);
+          return row ? row.inspected : 0;
+        }),
+        backgroundColor: colors[idx % colors.length]
+      }));
+      new Chart(ctx, {
+        type: 'bar',
+        data: { labels: dates, datasets },
+        options: { scales: { y: { beginAtZero: true } } }
+      });
+    }
+  }
+
+  const customerData = getData('customer-data');
+  if (customerData && customerData.length) {
+    const ctx = document.getElementById('customerChart');
+    if (ctx) {
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: customerData.map(c => c.customer),
+          datasets: [{
+            label: 'Reject Rate',
+            data: customerData.map(c => c.rate),
+            backgroundColor: 'rgba(255, 159, 64, 0.7)'
+          }]
+        },
+        options: { scales: { y: { beginAtZero: true } } }
+      });
+    }
+  }
+
+  const yieldData = getData('yield-data');
+  if (yieldData && yieldData.length) {
+    const ctx = document.getElementById('yieldChart');
+    if (ctx) {
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: yieldData.map(y => y.report_date),
+          datasets: [{
+            label: 'Yield',
+            data: yieldData.map(y => y.yield),
+            fill: false,
+            borderColor: 'rgba(75, 192, 192, 1)'
+          }]
+        },
+        options: { scales: { y: { beginAtZero: true, max: 1 } } }
+      });
+    }
+  }
+
   if (window.jQuery) {
     $('#assemblyTable').DataTable();
   }

--- a/templates/aoi_dashboard.html
+++ b/templates/aoi_dashboard.html
@@ -6,13 +6,43 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
   <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js" defer></script>
   <script id="operator-data" type="application/json">{{ operators|tojson }}</script>
+  <script id="shift-data" type="application/json">{{ shift_totals|tojson }}</script>
+  <script id="customer-data" type="application/json">{{ customer_rates|tojson }}</script>
+  <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
 {% endblock %}
 {% block content %}
   <a href="{{ url_for('aoi_report') }}">← AOI</a>
   <h1>AOI Dashboard</h1>
+  <form method="get" class="filters">
+    <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label>
+    <label>End: <input type="date" name="end" value="{{ end or '' }}"></label>
+    <label>Customer:
+      <select name="customer">
+        <option value="">All</option>
+        {% for c in customers %}
+        <option value="{{ c }}" {% if c == selected_customer %}selected{% endif %}>{{ c }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Shift:
+      <select name="shift">
+        <option value="">All</option>
+        {% for s in shifts %}
+        <option value="{{ s }}" {% if s == selected_shift %}selected{% endif %}>{{ s }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit">Apply</button>
+  </form>
   <h2>Top Operators by Inspected Quantity</h2>
   <canvas id="operatorsChart"></canvas>
+  <h2>Shift Totals</h2>
+  <canvas id="shiftChart"></canvas>
+  <h2>Customer Reject Rates</h2>
+  <canvas id="customerChart"></canvas>
+  <h2>Overall Yield Over Time</h2>
+  <canvas id="yieldChart"></canvas>
   <h2>Assembly Performance</h2>
   <table id="assemblyTable">
     <thead>


### PR DESCRIPTION
## Summary
- Add date, customer, and shift filters to AOI dashboard queries
- Compute shift-level totals, customer reject rates, and overall yield series
- Visualize new metrics with bar and line charts on dashboard

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689b21f95af483259cfde005086256c8