### PR TITLE
Handle empty AOI uploads

### DIFF
--- a/run.py
+++ b/run.py
@@ -7,6 +7,7 @@ from flask import (
     jsonify,
     send_from_directory,
     session,
+    flash,
 )
 from functools import wraps
 import os
@@ -382,7 +383,10 @@ def aoi_report():
                         i += 1
                 else:
                     i += 1
-
+            if not records:
+                conn.close()
+                flash('No AOI records found in the uploaded file.')
+                return redirect(url_for('aoi_report', view='upload'))
             if records:
                 conn.executemany(
                     'INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?)',

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -24,7 +24,7 @@
           <label>Excel File
             <input type="file" name="excel_file" accept=".xls,.xlsx" required>
           </label><br>
-          <p class="field-desc">If left blank, the date from the file will be used.</p>
+          <p class="field-desc">If left blank, the date from the file will be used. Files without AOI records will not be saved.</p>
           <button type="submit">Upload</button>
         </form>
       </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,15 @@
     {% endif %}
   </div>
   {% endif %}
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <ul class="flash-messages">
+        {% for message in messages %}
+        <li>{{ message }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  {% endwith %}
   {% block content %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show flash messages from all pages
- reject AOI uploads with no data and skip database commit/HTML generation
- note in AOI upload form that empty files are ignored

## Testing
- `pytest`
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_689b266ba6a48325be98b2aaf212702d