### PR TITLE
Validate AOI report dates before upload

### DIFF
--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -3,6 +3,9 @@
 {% block content %}
   <a href="/">← Home</a>
   <h1>AOI Daily Report</h1>
+  {% if error %}
+    <p class="error">{{ error }}</p>
+  {% endif %}
   <p>
     <a href="/aoi">View Reports</a>
     {% if current_user == 'ADMIN' or permissions['aoi'] %}


### PR DESCRIPTION
## Summary
- prevent uploads without a report date and show an error
- add NOT NULL constraint to AOI report dates and handle integrity errors
- surface upload errors in the AOI template

## Testing
- `python -m py_compile run.py`
- `sqlite3 spcapp.db "SELECT DISTINCT report_date FROM aoi_reports ORDER BY report_date DESC;"`


------
https://chatgpt.com/codex/tasks/task_e_689b2657c0ac832585bb6fbfa8f639ff