### PR TITLE
Enable inline table editing for admins

### DIFF
--- a/static/js/editable.js
+++ b/static/js/editable.js
@@ -1,0 +1,39 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const isAdmin = document.body.dataset.admin === 'true';
+  if (!isAdmin) return;
+
+  document.querySelectorAll('table').forEach(table => {
+    table.addEventListener('dblclick', e => {
+      const cell = e.target.closest('td');
+      if (!cell || cell.querySelector('input')) return;
+      const original = cell.textContent.trim();
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = original;
+      cell.textContent = '';
+      cell.appendChild(input);
+      input.focus();
+
+      const finish = () => {
+        const value = input.value.trim();
+        cell.removeChild(input);
+        cell.textContent = value;
+        const row = cell.parentElement;
+        const cells = Array.from(row.querySelectorAll('td'));
+        if (cells.every(td => td.textContent.trim() === '')) {
+          row.remove();
+        }
+      };
+
+      input.addEventListener('blur', finish);
+      input.addEventListener('keydown', ev => {
+        if (ev.key === 'Enter') {
+          input.blur();
+        } else if (ev.key === 'Escape') {
+          input.value = original;
+          input.blur();
+        }
+      });
+    });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,9 +5,10 @@
   <title>{% block title %}SPCApp{% endblock %}</title>
   <link rel="stylesheet" href="/static/css/style.css">
   <script src="/static/js/theme.js" defer></script>
+  <script src="/static/js/editable.js" defer></script>
   {% block head_extra %}{% endblock %}
 </head>
-<body>
+<body data-admin="{{ 'true' if current_user == 'ADMIN' else 'false' }}">
   {% if current_user %}
   <div class="topbar">
     <span class="user-label">user:{{ current_user }}</span>


### PR DESCRIPTION
## Summary
- Allow admin users to edit table cells via double-click
- Automatically remove rows when all cells are emptied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5a94531c83258b99075e67913e57