### PR TITLE
Add editable part markings update

### DIFF
--- a/run.py
+++ b/run.py
@@ -335,6 +335,36 @@ def part_markings():
     conn.close()
     return render_template('part_markings.html', markings=rows)
 
+
+@app.route('/part-markings/<int:row_id>', methods=['PUT'])
+@login_required
+def update_part_marking(row_id):
+    if not has_permission('part_markings'):
+        return jsonify(error='Forbidden'), 403
+    data = request.json or {}
+    field = data.get('field')
+    value = data.get('value', '')
+    allowed = {
+        'part_number',
+        'mfg_number1',
+        'mfg_number2',
+        'manufacturer',
+        'verified_markings',
+    }
+    if field not in allowed:
+        return jsonify(error='Invalid field'), 400
+    try:
+        conn = get_db()
+        conn.execute(
+            f'UPDATE verified_markings SET {field} = ? WHERE id = ?',
+            (value, row_id),
+        )
+        conn.commit()
+        conn.close()
+        return jsonify(success=True)
+    except Exception as e:
+        return jsonify(error=str(e)), 500
+
 @app.route('/aoi', methods=['GET', 'POST'])
 @login_required
 def aoi_report():

--- a/static/js/editable.js
+++ b/static/js/editable.js
@@ -14,14 +14,32 @@ window.addEventListener('DOMContentLoaded', () => {
       cell.appendChild(input);
       input.focus();
 
-      const finish = () => {
+      const finish = async () => {
         const value = input.value.trim();
         cell.removeChild(input);
         cell.textContent = value;
         const row = cell.parentElement;
-        const cells = Array.from(row.querySelectorAll('td'));
-        if (cells.every(td => td.textContent.trim() === '')) {
-          row.remove();
+        const id = row.dataset.id;
+        const fields = ['verified_markings','manufacturer','mfg_number2','mfg_number1','part_number'];
+        const field = fields[cell.cellIndex];
+        if (!id || !field) {
+          cell.textContent = original;
+          return;
+        }
+        try {
+          const resp = await fetch(`/part-markings/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ field, value })
+          });
+          const data = await resp.json();
+          if (!data.success) throw new Error(data.error || '');
+          const cells = Array.from(row.querySelectorAll('td'));
+          if (cells.every(td => td.textContent.trim() === '')) {
+            row.remove();
+          }
+        } catch (err) {
+          cell.textContent = original;
         }
       };
 

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -69,7 +69,7 @@
         </thead>
         <tbody>
           {% for row in markings %}
-          <tr>
+          <tr data-id="{{ row['id'] }}">
             <td>{{ row['verified_markings'] }}</td>
             <td>{{ row['manufacturer'] }}</td>
             <td>{{ row['mfg_number2'] }}</td>


### PR DESCRIPTION
## Summary
- Allow inline editing of part markings and persist changes via new PUT endpoint
- Expose row IDs in part markings table to support client-side updates
- Send fetch requests on cell edit and revert on server errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5f1072a48325ac838bbc9ac02ebd