### PR TITLE
Enable deleting part markings via API and front-end

### DIFF
--- a/run.py
+++ b/run.py
@@ -335,6 +335,23 @@ def part_markings():
     conn.close()
     return render_template('part_markings.html', markings=rows)
 
+
+@app.route('/part-markings/<int:marking_id>', methods=['DELETE'])
+@login_required
+def delete_part_marking(marking_id: int):
+    if not has_permission('part_markings'):
+        return jsonify({'error': 'Forbidden'}), 403
+    conn = get_db()
+    cur = conn.execute(
+        'DELETE FROM verified_markings WHERE id = ?', (marking_id,)
+    )
+    conn.commit()
+    deleted = cur.rowcount
+    conn.close()
+    if deleted:
+        return jsonify({'status': 'deleted'})
+    return jsonify({'error': 'Not found'}), 404
+
 @app.route('/aoi', methods=['GET', 'POST'])
 @login_required
 def aoi_report():

--- a/static/js/editable.js
+++ b/static/js/editable.js
@@ -15,13 +15,29 @@ window.addEventListener('DOMContentLoaded', () => {
       input.focus();
 
       const finish = () => {
+        const row = cell.parentElement;
+        const cells = Array.from(row.querySelectorAll('td'));
+        const originals = cells.map(td => td.textContent);
         const value = input.value.trim();
         cell.removeChild(input);
         cell.textContent = value;
-        const row = cell.parentElement;
-        const cells = Array.from(row.querySelectorAll('td'));
         if (cells.every(td => td.textContent.trim() === '')) {
-          row.remove();
+          const id = row.dataset.id;
+          if (!id) {
+            cells.forEach((td, i) => td.textContent = originals[i]);
+            return;
+          }
+          fetch(`/part-markings/${id}`, { method: 'DELETE' })
+            .then(resp => {
+              if (resp.ok) {
+                row.remove();
+              } else {
+                cells.forEach((td, i) => td.textContent = originals[i]);
+              }
+            })
+            .catch(() => {
+              cells.forEach((td, i) => td.textContent = originals[i]);
+            });
         }
       };
 

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -69,7 +69,7 @@
         </thead>
         <tbody>
           {% for row in markings %}
-          <tr>
+          <tr data-id="{{ row['id'] }}">
             <td>{{ row['verified_markings'] }}</td>
             <td>{{ row['manufacturer'] }}</td>
             <td>{{ row['mfg_number2'] }}</td>


### PR DESCRIPTION
## Summary
- add backend DELETE endpoint for part markings
- include record IDs in part-markings table rows
- allow editable rows to trigger backend DELETE and restore on failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5f6bfbd083258b9ce636b2af698b