### PR TITLE
Add admin row deletion for tables

### DIFF
--- a/run.py
+++ b/run.py
@@ -365,6 +365,21 @@ def update_part_marking(row_id):
     except Exception as e:
         return jsonify(error=str(e)), 500
 
+
+@app.route('/part-markings/<int:row_id>', methods=['DELETE'])
+@login_required
+def delete_part_marking(row_id):
+    if not has_permission('part_markings'):
+        return jsonify(error='Forbidden'), 403
+    try:
+        conn = get_db()
+        conn.execute('DELETE FROM verified_markings WHERE id = ?', (row_id,))
+        conn.commit()
+        conn.close()
+        return jsonify(success=True)
+    except Exception as e:
+        return jsonify(error=str(e)), 500
+
 @app.route('/aoi', methods=['GET', 'POST'])
 @login_required
 def aoi_report():
@@ -537,6 +552,21 @@ def aoi_report():
         selected_customer=customer,
         selected_shift=shift_filter,
     )
+
+
+@app.route('/aoi/<int:row_id>', methods=['DELETE'])
+@login_required
+def delete_aoi_record(row_id):
+    if not has_permission('aoi'):
+        return jsonify(error='Forbidden'), 403
+    try:
+        conn = get_db()
+        conn.execute('DELETE FROM aoi_reports WHERE id = ?', (row_id,))
+        conn.commit()
+        conn.close()
+        return jsonify(success=True)
+    except Exception as e:
+        return jsonify(error=str(e)), 500
 
 @app.route('/analysis', methods=['GET', 'POST'])
 @login_required

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -109,5 +109,24 @@ window.addEventListener('DOMContentLoaded', () => {
   if (window.jQuery) {
     $('#assemblyTable').DataTable();
   }
+
+  const table = document.querySelector('#aoi-table table');
+  if (table) {
+    table.addEventListener('click', async e => {
+      if (!e.target.classList.contains('delete-row')) return;
+      const row = e.target.closest('tr');
+      const id = row.dataset.id;
+      if (!id || !confirm('Delete this entry?')) return;
+      try {
+        const resp = await fetch(`/aoi/${id}`, { method: 'DELETE' });
+        const data = await resp.json();
+        if (data.success) {
+          row.remove();
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
 });
 

--- a/static/js/editable.js
+++ b/static/js/editable.js
@@ -2,10 +2,10 @@ window.addEventListener('DOMContentLoaded', () => {
   const isAdmin = document.body.dataset.admin === 'true';
   if (!isAdmin) return;
 
-  document.querySelectorAll('table').forEach(table => {
+  document.querySelectorAll('table.editable').forEach(table => {
     table.addEventListener('dblclick', e => {
       const cell = e.target.closest('td');
-      if (!cell || cell.querySelector('input')) return;
+      if (!cell || cell.querySelector('input') || cell.classList.contains('no-edit')) return;
       const original = cell.textContent.trim();
       const input = document.createElement('input');
       input.type = 'text';

--- a/static/js/part_markings.js
+++ b/static/js/part_markings.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const searchInput = document.getElementById('search-part-number');
   const searchBtn = document.getElementById('search-btn');
+  const table = document.querySelector('#markings-table table');
 
   function runSearch() {
     const term = searchInput.value.trim();
@@ -27,4 +28,22 @@ document.addEventListener('DOMContentLoaded', () => {
       runSearch();
     }
   });
+
+  if (table) {
+    table.addEventListener('click', async e => {
+      if (!e.target.classList.contains('delete-row')) return;
+      const row = e.target.closest('tr');
+      const id = row.dataset.id;
+      if (!id || !confirm('Delete this entry?')) return;
+      try {
+        const resp = await fetch(`/part-markings/${id}`, { method: 'DELETE' });
+        const data = await resp.json();
+        if (data.success) {
+          row.remove();
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
 });

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -138,11 +138,14 @@
             <th>Quantity Inspected</th>
             <th>Quantity Rejected</th>
             <th>Additional Information</th>
+            {% if current_user == 'ADMIN' or permissions['aoi'] %}
+            <th>Actions</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody>
           {% for r in records %}
-          <tr>
+          <tr data-id="{{ r['id'] }}">
             <td>{{ r['report_date'] }}</td>
             <td>{{ r['shift'] }}</td>
             <td>{{ r['operator'] }}</td>
@@ -151,6 +154,9 @@
             <td>{{ r['qty_inspected'] }}</td>
             <td>{{ r['qty_rejected'] }}</td>
             <td>{{ r['additional_info'] }}</td>
+            {% if current_user == 'ADMIN' or permissions['aoi'] %}
+            <td class="no-edit"><button type="button" class="delete-row">Delete</button></td>
+            {% endif %}
           </tr>
           {% endfor %}
         </tbody>

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -57,7 +57,7 @@
     </div>
     <div id="divider"></div>
     <div id="markings-table">
-      <table>
+      <table class="editable">
         <thead>
           <tr>
             <th>Verified Markings</th>
@@ -65,6 +65,9 @@
             <th>Mfg Number 2</th>
             <th>Mfg Number 1</th>
             <th>Part Number</th>
+            {% if current_user == 'ADMIN' or permissions['part_markings'] %}
+            <th>Actions</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody>
@@ -75,6 +78,9 @@
             <td>{{ row['mfg_number2'] }}</td>
             <td>{{ row['mfg_number1'] }}</td>
             <td>{{ row['part_number'] }}</td>
+            {% if current_user == 'ADMIN' or permissions['part_markings'] %}
+            <td class="no-edit"><button type="button" class="delete-row" title="Delete row">Delete</button></td>
+            {% endif %}
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- allow admins to delete part marking entries with backend persistence
- add deletion support for AOI report rows and update related templates
- restrict inline editing to designated tables and prevent editing of action cells

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6211bc408325a952b35562b5a514