### PR TITLE
Sort AOI reports by date and add chart zoom

### DIFF
--- a/run.py
+++ b/run.py
@@ -435,7 +435,9 @@ def aoi_report():
         return redirect(url_for('aoi_report'))
 
     # GET: fetch rows and analytics
-    rows = conn.execute('SELECT * FROM aoi_reports ORDER BY id').fetchall()
+    rows = conn.execute(
+        'SELECT * FROM aoi_reports ORDER BY report_date DESC, id DESC'
+    ).fetchall()
 
     start = request.args.get('start')
     end = request.args.get('end')

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -22,10 +22,11 @@ window.addEventListener('DOMContentLoaded', () => {
   };
 
   const ops = getData('operator-data');
+  const charts = {};
   if (ops && ops.length) {
     const ctx = document.getElementById('operatorsChart');
     if (ctx) {
-      new Chart(ctx, {
+      charts.operators = new Chart(ctx, {
         type: 'bar',
         data: {
           labels: ops.map(o => o.operator),
@@ -41,6 +42,7 @@ window.addEventListener('DOMContentLoaded', () => {
           }
         }
       });
+      ctx.addEventListener('click', () => openModal(charts.operators, 'Top Operators by Inspected Quantity'));
     }
   }
 
@@ -59,11 +61,12 @@ window.addEventListener('DOMContentLoaded', () => {
         }),
         backgroundColor: colors[idx % colors.length]
       }));
-      new Chart(ctx, {
+      charts.shift = new Chart(ctx, {
         type: 'bar',
         data: { labels: dates, datasets },
         options: { scales: { y: { beginAtZero: true } } }
       });
+      ctx.addEventListener('click', () => openModal(charts.shift, 'Shift Totals'));
     }
   }
 
@@ -71,7 +74,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (customerData && customerData.length) {
     const ctx = document.getElementById('customerChart');
     if (ctx) {
-      new Chart(ctx, {
+      charts.customer = new Chart(ctx, {
         type: 'bar',
         data: {
           labels: customerData.map(c => c.customer),
@@ -83,6 +86,7 @@ window.addEventListener('DOMContentLoaded', () => {
         },
         options: { scales: { y: { beginAtZero: true } } }
       });
+      ctx.addEventListener('click', () => openModal(charts.customer, 'Customer Reject Rates'));
     }
   }
 
@@ -90,7 +94,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (yieldData && yieldData.length) {
     const ctx = document.getElementById('yieldChart');
     if (ctx) {
-      new Chart(ctx, {
+      charts.yield = new Chart(ctx, {
         type: 'line',
         data: {
           labels: yieldData.map(y => y.report_date),
@@ -103,6 +107,7 @@ window.addEventListener('DOMContentLoaded', () => {
         },
         options: { scales: { y: { beginAtZero: true, max: 1 } } }
       });
+      ctx.addEventListener('click', () => openModal(charts.yield, 'Overall Yield Over Time'));
     }
   }
 
@@ -128,5 +133,41 @@ window.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  // Modal logic for charts
+  const modal = document.getElementById('chart-modal');
+  const modalCanvas = document.getElementById('chart-canvas');
+  const modalTitle = document.getElementById('chart-modal-title');
+  const closeModal = document.getElementById('close-chart-modal');
+  const downloadBtn = document.getElementById('download-chart-pdf');
+  let modalChart;
+
+  function openModal(chart, title) {
+    if (!modal || !modalCanvas) return;
+    if (modalChart) modalChart.destroy();
+    modalChart = new Chart(modalCanvas, {
+      type: chart.config.type,
+      data: structuredClone(chart.config.data),
+      options: structuredClone(chart.config.options)
+    });
+    if (modalTitle) modalTitle.textContent = title || '';
+    modal.style.display = 'block';
+  }
+
+  closeModal?.addEventListener('click', () => { modal.style.display = 'none'; });
+  window.addEventListener('click', e => { if (e.target === modal) modal.style.display = 'none'; });
+
+  downloadBtn?.addEventListener('click', () => {
+    if (!modalChart) return;
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF({ orientation: 'landscape' });
+    if (modalTitle) pdf.text(modalTitle.textContent, 10, 10);
+    const imgData = modalChart.toBase64Image();
+    const imgProps = pdf.getImageProperties(imgData);
+    const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
+    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+    pdf.addImage(imgData, 'PNG', 10, 20, pdfWidth, pdfHeight);
+    pdf.save('chart.pdf');
+  });
 });
 

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -9,6 +9,7 @@
   <script id="shift-data" type="application/json">{{ shift_totals|tojson }}</script>
   <script id="customer-data" type="application/json">{{ customer_rates|tojson }}</script>
   <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
 {% endblock %}
 {% block content %}
@@ -161,6 +162,15 @@
           {% endfor %}
         </tbody>
       </table>
+    </div>
+  </div>
+
+  <div id="chart-modal" class="modal">
+    <div class="modal-content">
+      <span id="close-chart-modal" class="close">&times;</span>
+      <h2 id="chart-modal-title"></h2>
+      <canvas id="chart-canvas"></canvas>
+      <button id="download-chart-pdf">Download PDF</button>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- sort AOI Daily Report entries by report date descending
- add chart modal with zoom and PDF download for AOI charts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b64cd66ec832597b8bdda6c705d9f