### PR TITLE
Sort AOI reports by date and add chart zoom

### DIFF
--- a/run.py
+++ b/run.py
@@ -435,7 +435,9 @@ def aoi_report():
         return redirect(url_for('aoi_report'))
 
     # GET: fetch rows and analytics
-    rows = conn.execute('SELECT * FROM aoi_reports ORDER BY id').fetchall()
+    rows = conn.execute(
+        'SELECT * FROM aoi_reports ORDER BY report_date DESC, id DESC'
+    ).fetchall()
 
     start = request.args.get('start')
     end = request.args.get('end')

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -9,6 +9,7 @@
   <script id="shift-data" type="application/json">{{ shift_totals|tojson }}</script>
   <script id="customer-data" type="application/json">{{ customer_rates|tojson }}</script>
   <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
 {% endblock %}
 {% block content %}
@@ -94,13 +95,13 @@
             <button type="submit">Apply</button>
           </form>
         </div>
-        <h2>Top Operators by Inspected Quantity</h2>
+        <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators" data-title="Top Operators by Inspected Quantity">Expand</button></h2>
         <canvas id="operatorsChart"></canvas>
-        <h2>Shift Totals</h2>
+        <h2>Shift Totals <button class="expand-chart" data-chart="shift" data-title="Shift Totals">Expand</button></h2>
         <canvas id="shiftChart"></canvas>
-        <h2>Customer Reject Rates</h2>
+        <h2>Customer Reject Rates <button class="expand-chart" data-chart="customer" data-title="Customer Reject Rates">Expand</button></h2>
         <canvas id="customerChart"></canvas>
-        <h2>Overall Yield Over Time</h2>
+        <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield" data-title="Overall Yield Over Time">Expand</button></h2>
         <canvas id="yieldChart"></canvas>
         <h2>Assembly Performance</h2>
         <table id="assemblyTable">
@@ -161,6 +162,15 @@
           {% endfor %}
         </tbody>
       </table>
+    </div>
+  </div>
+
+  <div id="chart-modal" class="modal">
+    <div class="modal-content">
+      <span id="close-chart-modal" class="close">&times;</span>
+      <h2 id="chart-modal-title"></h2>
+      <canvas id="chart-canvas"></canvas>
+      <button id="download-chart-pdf">Download PDF</button>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- sort AOI Daily Report entries by report date descending
- add expand buttons next to AOI charts to open modal with PDF download

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b64cd66ec832597b8bdda6c705d9f