### PR TITLE
Add expandable AOI charts with download option

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -105,6 +105,11 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
   font-size: 1.2em;
 }
 
+.expand-chart {
+  margin-left: 8px;
+  font-size: 0.8em;
+}
+
 .action-card p {
   margin: 0 0 10px;
   color: #555;

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -154,6 +154,15 @@ window.addEventListener('DOMContentLoaded', () => {
     modal.style.display = 'block';
   }
 
+  document.querySelectorAll('.expand-chart').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const key = btn.dataset.chart;
+      const title = btn.dataset.title || '';
+      const chart = charts[key];
+      if (chart) openModal(chart, title);
+    });
+  });
+
   closeModal?.addEventListener('click', () => { modal.style.display = 'none'; });
   window.addEventListener('click', e => { if (e.target === modal) modal.style.display = 'none'; });
 

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -95,13 +95,13 @@
             <button type="submit">Apply</button>
           </form>
         </div>
-        <h2>Top Operators by Inspected Quantity</h2>
+        <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators" data-title="Top Operators by Inspected Quantity" title="Expand chart">Expand</button></h2>
         <canvas id="operatorsChart"></canvas>
-        <h2>Shift Totals</h2>
+        <h2>Shift Totals <button class="expand-chart" data-chart="shift" data-title="Shift Totals" title="Expand chart">Expand</button></h2>
         <canvas id="shiftChart"></canvas>
-        <h2>Customer Reject Rates</h2>
+        <h2>Customer Reject Rates <button class="expand-chart" data-chart="customer" data-title="Customer Reject Rates" title="Expand chart">Expand</button></h2>
         <canvas id="customerChart"></canvas>
-        <h2>Overall Yield Over Time</h2>
+        <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield" data-title="Overall Yield Over Time" title="Expand chart">Expand</button></h2>
         <canvas id="yieldChart"></canvas>
         <h2>Assembly Performance</h2>
         <table id="assemblyTable">


### PR DESCRIPTION
## Summary
- Add Expand buttons beside AOI chart titles to open charts in modal for easier viewing
- Style and hook up new buttons to chart modal with existing download feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b73330838832596dad8e7f8e3da78