### PR TITLE
Refine AOI dashboard charts

### DIFF
--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -95,13 +95,13 @@
             <button type="submit">Apply</button>
           </form>
         </div>
-        <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators" data-title="Top Operators by Inspected Quantity" title="Expand chart">Expand</button></h2>
+        <h2>Top Operators by Inspected Quantity</h2>
         <canvas id="operatorsChart"></canvas>
-        <h2>Shift Totals <button class="expand-chart" data-chart="shift" data-title="Shift Totals" title="Expand chart">Expand</button></h2>
+        <h2>Shift Totals</h2>
         <canvas id="shiftChart"></canvas>
-        <h2>Operator Reject Rates <button class="expand-chart" data-chart="customer" data-title="Customer Reject Rates" title="Expand chart">Expand</button></h2>
+        <h2>Operator Reject Rates</h2>
         <canvas id="customerChart"></canvas>
-        <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield" data-title="Overall Yield Over Time" title="Expand chart">Expand</button></h2>
+        <h2>Overall Yield Over Time</h2>
         <canvas id="yieldChart"></canvas>
         <h2>Assembly Performance</h2>
         <table id="assemblyTable">
@@ -165,13 +165,5 @@
     </div>
   </div>
 
-  <div id="chart-modal" class="modal">
-    <div class="modal-content">
-      <span id="close-chart-modal" class="close">&times;</span>
-      <h2 id="chart-modal-title"></h2>
-      <canvas id="chart-canvas"></canvas>
-      <button id="download-chart-pdf">Download PDF</button>
-    </div>
-  </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Remove non-functional chart expansion UI and related modal code
- Add stacked operator chart highlighting rejects and hide operator names for non-admins
- Display overall yield as percentages rather than decimals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca6c4401883259836321c1cadc17f