### PR TITLE
Align app styling with company colors

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,37 +1,55 @@
+:root {
+  --color-black: #000000;
+  --color-white: #f5f5f5;
+  --color-accent: #089e85;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 20px;
+  background: var(--color-white);
+  color: var(--color-black);
 }
-h1, p { color: #333; }
+h1, p { color: var(--color-black); }
+a { color: var(--color-accent); }
 .topbar {
   text-align: right;
-  color: #888;
+  color: var(--color-black);
   font-size: 0.8em;
 }
 .topbar a {
   margin-left: 10px;
-  color: #888;
+  color: var(--color-accent);
 }
 .topbar button {
   margin-left: 10px;
   font-size: 0.8em;
+  background: var(--color-accent);
+  color: var(--color-white);
+  border: none;
+  padding: 2px 6px;
+  cursor: pointer;
 }
 .widgets { display: flex; gap: 20px; margin-top: 20px; }
 .widget {
   flex:1;
-  border:1px solid #ccc;
+  border:1px solid var(--color-black);
   border-radius:8px;
   padding:20px;
   text-align:center;
   cursor:pointer;
-  transition:background 0.3s;
+  transition:background 0.3s,color 0.3s;
+  background: var(--color-white);
 }
-.widget:hover { background:#f9f9f9; }
+.widget:hover {
+  background: var(--color-accent);
+  color: var(--color-white);
+}
 
 /* Job preview section */
 .job-previews { margin: 0 -20px 20px -20px; width: calc(100% + 40px); }
 .job-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; width: 100%; }
-.job-preview { margin-bottom: 0; padding: 10px; border: 1px solid #ccc; border-radius: 4px; }
+.job-preview { margin-bottom: 0; padding: 10px; border: 1px solid var(--color-black); border-radius: 4px; }
 .job-preview.warning { background: #fff3cd; }
 .job-preview.danger { background: #f8d7da; }
 .job-preview ul { list-style: none; padding-left: 0; margin: 5px 0 0 0; }
@@ -40,7 +58,7 @@ h1, p { color: #333; }
 /* MOAT stats text */
 .moat-stats {
   font-size: 0.9em;
-  color: #555;
+  color: var(--color-black);
   margin-bottom: 8px;
 }
 #show-uploads-btn { font-size: 0.9em; }
@@ -56,17 +74,17 @@ h1, p { color: #333; }
   background-color: rgba(0,0,0,0.4);
 }
 .modal-content {
-  background-color: #fefefe;
+  background-color: var(--color-white);
   margin: 5% auto;
   padding: 20px;
-  border: 1px solid #888;
+  border: 1px solid var(--color-black);
   width: 80%;       /* Make modal wider */
   max-width: none;
   border-radius: 8px;
   overflow-x: auto; /* Enable horizontal scroll */
 }
 .close {
-  color: #aaa;
+  color: var(--color-black);
   float: right;
   font-size: 24px;
   font-weight: bold;
@@ -75,15 +93,15 @@ h1, p { color: #333; }
   text-align: end;
   align-items: end;
 }
-.close:hover { color: #000; }
+.close:hover { color: var(--color-accent); }
 
 /* Analysis split-screen */
 #container { display:flex; height:80vh; margin-top:20px; }
 #analysis-actions, #markings-actions, #aoi-actions { flex:1; padding:20px; overflow:auto; }
-#divider { width:4px; background:#ccc; cursor:col-resize; }
+#divider { width:4px; background:var(--color-accent); cursor:col-resize; }
 #moat-table, #markings-table, #aoi-table { flex:1; padding:10px; overflow:auto; }
 table { width:100%; border-collapse:collapse; }
-th, td { border:1px solid #ccc; padding:8px; text-align:center; }
+th, td { border:1px solid var(--color-black); padding:8px; text-align:center; }
 .highlight { background: yellow; }
 
 /* Action panels */
@@ -94,8 +112,8 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
 }
 
 .action-card {
-  background: #f4f7f9;
-  border: 1px solid #ccc;
+  background: var(--color-white);
+  border: 1px solid var(--color-black);
   border-radius: 8px;
   padding: 15px;
 }
@@ -112,13 +130,13 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
 
 .action-card p {
   margin: 0 0 10px;
-  color: #555;
+  color: var(--color-black);
   font-size: 0.9em;
 }
 
 .field-desc {
   font-size: 0.8em;
-  color: #666;
+  color: var(--color-black);
   margin-top: 6px;
 }
 
@@ -137,7 +155,7 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
   width: 95%;
   padding: 6px;
   margin-top: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-black);
   border-radius: 4px;
 }
 
@@ -145,14 +163,15 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
   margin-top: 10px;
   padding: 8px 12px;
   border: none;
-  background: #007bff;
-  color: #fff;
+  background: var(--color-accent);
+  color: var(--color-white);
   border-radius: 4px;
   cursor: pointer;
 }
 
 .action-card button:hover {
-  background: #0056b3;
+  background: var(--color-black);
+  color: var(--color-white);
 }
 
 .home-title {
@@ -164,7 +183,7 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
 }
 
 .home-title img {
-    background-color: #121212;
+    background-color: var(--color-black);
     padding: 5px;
     border-radius: 7px;
 }
@@ -190,24 +209,24 @@ th, td { border:1px solid #ccc; padding:8px; text-align:center; }
 
 /* Dark mode styles */
 body.dark-mode {
-  background: #121212;
-  color: #e0e0e0;
+  background: var(--color-black);
+  color: var(--color-white);
 }
 body.dark-mode h1,
 body.dark-mode p,
 body.dark-mode label,
-body.dark-mode span,
-body.dark-mode a {
-  color: #e0e0e0;
+body.dark-mode span {
+  color: var(--color-white);
 }
-body.dark-mode .topbar { color: #bbb; }
-body.dark-mode .topbar a { color: #bbb; }
-body.dark-mode .widget { border-color: #555; }
-body.dark-mode .widget:hover { background: #1e1e1e; }
-body.dark-mode .action-card { background: #1e1e1e; border-color: #444; }
-body.dark-mode .action-card p { color: #ccc; }
-body.dark-mode table { border-color: #555; }
+body.dark-mode a { color: var(--color-accent); }
+body.dark-mode .topbar { color: var(--color-white); }
+body.dark-mode .topbar a { color: var(--color-accent); }
+body.dark-mode .widget { border-color: var(--color-white); }
+body.dark-mode .widget:hover { background: var(--color-accent); color: var(--color-white); }
+body.dark-mode .action-card { background: var(--color-black); border-color: var(--color-white); }
+body.dark-mode .action-card p { color: var(--color-white); }
+body.dark-mode table { border-color: var(--color-white); }
 body.dark-mode th,
-body.dark-mode td { border-color: #555; }
+body.dark-mode td { border-color: var(--color-white); }
 body.dark-mode .job-preview.warning { background: #b7b700; border-color: #b7b700; color: #fff; }
 body.dark-mode .job-preview.danger { background: #660000; border-color: #660000; color: #fff; }


### PR DESCRIPTION
## Summary
- introduce black, white, and green accent variables and apply them throughout the UI
- restyle widgets, buttons, and layout to use company palette while retaining purposeful colors
- update dark mode to mirror the new color scheme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d06d81dc08325967ee913a2e3cfde