### PR TITLE
Add per-user permissions and user management tab

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -28,21 +28,29 @@
       <h2>Jobs</h2>
       <p>Manage Floor Jobs (<i>in progress</i>)</p>
     </div>
+    {% if current_user == 'ADMIN' or permissions.get('analysis') %}
     <div class="widget" onclick="location.href='/analysis'">
       <h2>Data Analysis</h2>
       <p>Upload And Data Mine Reports From SPC</p>
     </div>
+    {% endif %}
+    {% if current_user == 'ADMIN' or permissions.get('part_markings') %}
     <div class="widget" onclick="location.href='/part-markings'">
       <h2>Verified Part Markings</h2>
       <p>Lookup Part Numbers To Find Their Verified Part Markings</p>
     </div>
+    {% endif %}
+    {% if current_user == 'ADMIN' or permissions.get('aoi') %}
     <div class="widget" onclick="location.href='/aoi'">
       <h2>AOI Daily Report</h2>
       <p>View and Upload AOI Reports With Data Insights.</p>
     </div>
+    {% endif %}
+    {% if current_user == 'ADMIN' or permissions.get('dashboard') %}
     <div class="widget" onclick="location.href='#'">
       <h2>SPC Dashboard</h2>
       <p>Statistical Controls (<i>in progress</i>)</p>
     </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,10 +5,11 @@
     <div class="action-card">
       <h1>Login</h1>
       <form method="post">
-        <label>User Type
-          <select name="role">
-            <option value="ADMIN">ADMIN</option>
-            <option value="USER">USER</option>
+        <label>User
+          <select name="username">
+            {% for u in users %}
+            <option value="{{ u }}">{{ u }}</option>
+            {% endfor %}
           </select>
         </label><br>
         <label>Password
@@ -20,3 +21,4 @@
     </div>
   </div>
 {% endblock %}
+

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,13 +1,56 @@
 {% extends 'base.html' %}
 {% block title %}Settings{% endblock %}
+{% block head_extra %}
+<style>
+  .tab { display: none; }
+  .tab.active { display: block; }
+  .tab-buttons button { margin-right: 5px; }
+  .user-row { margin-bottom: 10px; }
+</style>
+<script>
+function showTab(id){
+  document.querySelectorAll('.tab').forEach(el=>el.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+}
+document.addEventListener('DOMContentLoaded', function(){ showTab('users'); });
+function toggleAddUser(){
+  var form = document.getElementById('add-user');
+  form.style.display = form.style.display === 'block' ? 'none' : 'block';
+}
+</script>
+{% endblock %}
 {% block content %}
   <a href="/">← Home</a>
   <h1>Settings</h1>
-  <h2>Permissions</h2>
-  <form method="post">
-    <label><input type="checkbox" name="permissions" value="part_markings" {% if permissions['part_markings'] %}checked{% endif %}> Part Markings Upload/Input</label><br>
-    <label><input type="checkbox" name="permissions" value="aoi" {% if permissions['aoi'] %}checked{% endif %}> AOI Report Upload</label><br>
-    <label><input type="checkbox" name="permissions" value="analysis" {% if permissions['analysis'] %}checked{% endif %}> PPM Report Upload</label><br>
-    <button type="submit">Save</button>
-  </form>
+  <div class="tab-buttons">
+    <button type="button" onclick="showTab('users')">User Management</button>
+  </div>
+  <div id="users" class="tab">
+    <h2>User Management</h2>
+    {% for u in users %}
+    <form method="post" class="user-row">
+      <input type="hidden" name="user_id" value="{{ u['id'] }}">
+      <input type="hidden" name="action" value="update">
+      <strong>{{ u['username'] }}</strong>
+      <label><input type="checkbox" name="privileges" value="part_markings" {% if u['part_markings'] %}checked{% endif %}> Part Markings</label>
+      <label><input type="checkbox" name="privileges" value="aoi" {% if u['aoi'] %}checked{% endif %}> AOI Report</label>
+      <label><input type="checkbox" name="privileges" value="analysis" {% if u['analysis'] %}checked{% endif %}> Data Analysis</label>
+      <label><input type="checkbox" name="privileges" value="dashboard" {% if u['dashboard'] %}checked{% endif %}> SPC Dashboard</label>
+      <button type="submit">Save</button>
+      <button type="submit" name="action" value="delete">Delete</button>
+    </form>
+    {% endfor %}
+    <button type="button" onclick="toggleAddUser()">+</button>
+    <form id="add-user" method="post" style="display:none;margin-top:10px;">
+      <input type="hidden" name="action" value="add">
+      <input type="text" name="username" placeholder="Username" required>
+      <input type="password" name="password" placeholder="Password" required>
+      <label><input type="checkbox" name="privileges" value="part_markings" checked> Part Markings</label>
+      <label><input type="checkbox" name="privileges" value="aoi"> AOI Report</label>
+      <label><input type="checkbox" name="privileges" value="analysis"> Data Analysis</label>
+      <label><input type="checkbox" name="privileges" value="dashboard"> SPC Dashboard</label>
+      <button type="submit">Add</button>
+    </form>
+  </div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Introduce `users` table with per-feature permissions and seed default ADMIN/USER accounts
- Expand settings page with new User Management tab to add/update/delete users and set privileges
- Update login and home pages to respect per-user privileges for AOI, Data Analysis and Dashboard sections

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1cdb5d288325ad91c11d5d487978