### PR TITLE
Add C-suite permission for manager access

### DIFF
--- a/run.py
+++ b/run.py
@@ -109,17 +109,29 @@ def init_db():
             aoi INTEGER DEFAULT 0,
             analysis INTEGER DEFAULT 0,
             dashboard INTEGER DEFAULT 0,
+            c_suite INTEGER DEFAULT 0,
             is_admin INTEGER DEFAULT 0
         )
     ''')
+
+    # Older database versions may lack the `c_suite` column. Ensure it exists so
+    # privileged users beyond the hard-coded ADMIN account can be granted the
+    # same access rights.
+    existing_cols = [r['name'] for r in conn.execute("PRAGMA table_info(users)").fetchall()]
+    if 'c_suite' not in existing_cols:
+        conn.execute('ALTER TABLE users ADD COLUMN c_suite INTEGER DEFAULT 0')
+
     conn.execute(
-        'INSERT OR IGNORE INTO users (username, password, part_markings, aoi, analysis, dashboard, is_admin) VALUES (?,?,?,?,?,?,?)',
-        ('ADMIN', 'MasterAdmin', 1, 1, 1, 1, 1),
+        'INSERT OR IGNORE INTO users (username, password, part_markings, aoi, analysis, dashboard, c_suite, is_admin) VALUES (?,?,?,?,?,?,?,?)',
+        ('ADMIN', 'MasterAdmin', 1, 1, 1, 1, 1, 1),
     )
     conn.execute(
-        'INSERT OR IGNORE INTO users (username, password, part_markings, aoi, analysis, dashboard, is_admin) VALUES (?,?,?,?,?,?,?)',
-        ('USER', 'fuji', 1, 0, 0, 0, 0),
+        'INSERT OR IGNORE INTO users (username, password, part_markings, aoi, analysis, dashboard, c_suite, is_admin) VALUES (?,?,?,?,?,?,?,?)',
+        ('USER', 'fuji', 1, 0, 0, 0, 0, 0),
     )
+    # Ensure existing ADMIN row gains C-suite privileges if it pre-existed the
+    # column addition.
+    conn.execute("UPDATE users SET c_suite=1 WHERE username='ADMIN'")
     conn.commit()
     conn.close()
 
@@ -143,14 +155,14 @@ def has_permission(feature: str) -> bool:
     conn = get_db()
     try:
         row = conn.execute(
-            f'SELECT is_admin, {feature} as allowed FROM users WHERE username = ?',
+            f'SELECT is_admin, c_suite, {feature} as allowed FROM users WHERE username = ?',
             (user,),
         ).fetchone()
     finally:
         conn.close()
     if not row:
         return False
-    if row['is_admin']:
+    if row['is_admin'] or row['c_suite']:
         return True
     return bool(row['allowed'])
 
@@ -159,21 +171,31 @@ def has_permission(feature: str) -> bool:
 def inject_globals():
     user = session.get('user')
     perms = {}
+    is_admin = False
     if user:
         conn = get_db()
         row = conn.execute(
-            'SELECT part_markings, aoi, analysis, dashboard FROM users WHERE username = ?',
+            'SELECT part_markings, aoi, analysis, dashboard, is_admin, c_suite FROM users WHERE username = ?',
             (user,),
         ).fetchone()
         conn.close()
         if row:
-            perms = {
-                'part_markings': bool(row['part_markings']),
-                'aoi': bool(row['aoi']),
-                'analysis': bool(row['analysis']),
-                'dashboard': bool(row['dashboard']),
-            }
-    return dict(current_user=user, permissions=perms)
+            is_admin = bool(row['is_admin'] or row['c_suite'])
+            if is_admin:
+                perms = {
+                    'part_markings': True,
+                    'aoi': True,
+                    'analysis': True,
+                    'dashboard': True,
+                }
+            else:
+                perms = {
+                    'part_markings': bool(row['part_markings']),
+                    'aoi': bool(row['aoi']),
+                    'analysis': bool(row['analysis']),
+                    'dashboard': bool(row['dashboard']),
+                }
+    return dict(current_user=user, permissions=perms, is_admin=is_admin)
 
 # --- Routes ---
 @app.route('/login', methods=['GET', 'POST'])
@@ -203,9 +225,16 @@ def logout():
 @app.route('/settings', methods=['GET', 'POST'])
 @login_required
 def settings():
-    if session.get('user') != 'ADMIN':
-        return redirect(url_for('home'))
     conn = get_db()
+    user = session.get('user')
+    row = conn.execute(
+        'SELECT is_admin, c_suite FROM users WHERE username=?',
+        (user,),
+    ).fetchone()
+    if not row or not (row['is_admin'] or row['c_suite']):
+        conn.close()
+        return redirect(url_for('home'))
+
     if request.method == 'POST':
         action = request.form.get('action')
         if action == 'add':
@@ -213,7 +242,7 @@ def settings():
             password = request.form.get('password')
             privs = request.form.getlist('privileges')
             conn.execute(
-                'INSERT OR IGNORE INTO users (username, password, part_markings, aoi, analysis, dashboard, is_admin) VALUES (?,?,?,?,?,?,0)',
+                'INSERT OR IGNORE INTO users (username, password, part_markings, aoi, analysis, dashboard, c_suite, is_admin) VALUES (?,?,?,?,?,?,?,0)',
                 (
                     username,
                     password,
@@ -221,6 +250,7 @@ def settings():
                     1 if 'aoi' in privs else 0,
                     1 if 'analysis' in privs else 0,
                     1 if 'dashboard' in privs else 0,
+                    1 if 'c_suite' in privs else 0,
                 ),
             )
             conn.commit()
@@ -228,12 +258,13 @@ def settings():
             uid = request.form.get('user_id')
             privs = request.form.getlist('privileges')
             conn.execute(
-                'UPDATE users SET part_markings=?, aoi=?, analysis=?, dashboard=? WHERE id=?',
+                'UPDATE users SET part_markings=?, aoi=?, analysis=?, dashboard=?, c_suite=? WHERE id=?',
                 (
                     1 if 'part_markings' in privs else 0,
                     1 if 'aoi' in privs else 0,
                     1 if 'analysis' in privs else 0,
                     1 if 'dashboard' in privs else 0,
+                    1 if 'c_suite' in privs else 0,
                     uid,
                 ),
             )
@@ -243,7 +274,7 @@ def settings():
             conn.execute('DELETE FROM users WHERE id=?', (uid,))
             conn.commit()
     users = conn.execute(
-        'SELECT id, username, part_markings, aoi, analysis, dashboard FROM users WHERE username != ?',
+        'SELECT id, username, part_markings, aoi, analysis, dashboard, c_suite FROM users WHERE username != ?',
         ('ADMIN',),
     ).fetchall()
     conn.close()

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -15,7 +15,7 @@
     <div class="moat-stats">
       {% if total_rows %}
         Total rows: {{ total_rows }} | Table range: {{ earliest }} - {{ latest }}
-        {% if current_user == 'ADMIN' or permissions['analysis'] %}
+        {% if is_admin or permissions['analysis'] %}
         &nbsp;|&nbsp;
         <button id="show-uploads-btn" title="View or delete previously uploaded reports">Manage Uploads</button>
         {% endif %}
@@ -24,7 +24,7 @@
     <div id="container">
       <div id="analysis-actions">
         <div class="action-panel">
-          {% if current_user == 'ADMIN' or permissions['analysis'] %}
+          {% if is_admin or permissions['analysis'] %}
           <div class="action-card">
             <h2>Upload PPM Report</h2>
             <p class="desc">Import a PPM report (.xls or .xlsx) to analyze false call rates.</p>

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -18,7 +18,7 @@
   <div id="container">
     <div id="aoi-actions">
       <div class="action-panel">
-        {% if current_user == 'ADMIN' or permissions['aoi'] %}
+        {% if is_admin or permissions['aoi'] %}
         <div class="action-card collapsible-card">
           <h2 class="collapsible-header">Add New Entry</h2>
           <div class="collapsible-content">
@@ -143,7 +143,7 @@
             <th>Quantity Inspected</th>
             <th>Quantity Rejected</th>
             <th>Additional Information</th>
-            {% if current_user == 'ADMIN' or permissions['aoi'] %}
+            {% if is_admin or permissions['aoi'] %}
             <th>Actions</th>
             {% endif %}
           </tr>
@@ -159,7 +159,7 @@
             <td>{{ r['qty_inspected'] }}</td>
             <td>{{ r['qty_rejected'] }}</td>
             <td>{{ r['additional_info'] }}</td>
-            {% if current_user == 'ADMIN' or permissions['aoi'] %}
+            {% if is_admin or permissions['aoi'] %}
             <td class="no-edit"><button type="button" class="delete-row">Delete</button></td>
             {% endif %}
           </tr>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,13 +8,13 @@
   <script src="/static/js/editable.js" defer></script>
   {% block head_extra %}{% endblock %}
 </head>
-<body data-admin="{{ 'true' if current_user == 'ADMIN' else 'false' }}">
+<body data-admin="{{ 'true' if is_admin else 'false' }}">
   {% if current_user %}
   <div class="topbar">
     <span class="user-label">user:{{ current_user }}</span>
     <a href="{{ url_for('logout') }}">Logout</a>
     <button id="theme-toggle" type="button">Dark Mode</button>
-    {% if current_user == 'ADMIN' %}
+    {% if is_admin %}
       <a href="{{ url_for('settings') }}">Settings</a>
     {% endif %}
   </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -28,25 +28,25 @@
       <h2>Jobs</h2>
       <p>Manage Floor Jobs (<i>in progress</i>)</p>
     </div>
-    {% if current_user == 'ADMIN' or permissions.get('analysis') %}
+    {% if is_admin or permissions.get('analysis') %}
     <div class="widget" onclick="location.href='/analysis'">
       <h2>Data Analysis</h2>
       <p>Upload And Data Mine Reports From SPC</p>
     </div>
     {% endif %}
-    {% if current_user == 'ADMIN' or permissions.get('part_markings') %}
+    {% if is_admin or permissions.get('part_markings') %}
     <div class="widget" onclick="location.href='/part-markings'">
       <h2>Verified Part Markings</h2>
       <p>Lookup Part Numbers To Find Their Verified Part Markings</p>
     </div>
     {% endif %}
-    {% if current_user == 'ADMIN' or permissions.get('aoi') %}
+    {% if is_admin or permissions.get('aoi') %}
     <div class="widget" onclick="location.href='/aoi'">
       <h2>AOI Daily Report</h2>
       <p>View and Upload AOI Reports With Data Insights.</p>
     </div>
     {% endif %}
-    {% if current_user == 'ADMIN' or permissions.get('dashboard') %}
+    {% if is_admin or permissions.get('dashboard') %}
     <div class="widget" onclick="location.href='#'">
       <h2>SPC Dashboard</h2>
       <p>Statistical Controls (<i>in progress</i>)</p>

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -17,7 +17,7 @@
           <p class="field-desc">Highlight matching part number in the table.</p>
           <button id="search-btn" type="button" title="Highlight matching part number">Search</button>
         </div>
-        {% if current_user == 'ADMIN' or permissions['part_markings'] %}
+        {% if is_admin or permissions['part_markings'] %}
         <div class="action-card">
           <h2>Add New Entry</h2>
           <p class="desc">Use this form to add a single verified part marking.</p>
@@ -65,7 +65,7 @@
             <th>Mfg Number 2</th>
             <th>Mfg Number 1</th>
             <th>Part Number</th>
-            {% if current_user == 'ADMIN' or permissions['part_markings'] %}
+            {% if is_admin or permissions['part_markings'] %}
             <th>Actions</th>
             {% endif %}
           </tr>
@@ -78,7 +78,7 @@
             <td>{{ row['mfg_number2'] }}</td>
             <td>{{ row['mfg_number1'] }}</td>
             <td>{{ row['part_number'] }}</td>
-            {% if current_user == 'ADMIN' or permissions['part_markings'] %}
+            {% if is_admin or permissions['part_markings'] %}
             <td class="no-edit"><button type="button" class="delete-row" title="Delete row">Delete</button></td>
             {% endif %}
           </tr>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -36,6 +36,7 @@ function toggleAddUser(){
       <label><input type="checkbox" name="privileges" value="aoi" {% if u['aoi'] %}checked{% endif %}> AOI Report</label>
       <label><input type="checkbox" name="privileges" value="analysis" {% if u['analysis'] %}checked{% endif %}> Data Analysis</label>
       <label><input type="checkbox" name="privileges" value="dashboard" {% if u['dashboard'] %}checked{% endif %}> SPC Dashboard</label>
+      <label><input type="checkbox" name="privileges" value="c_suite" {% if u['c_suite'] %}checked{% endif %}> C-suite</label>
       <button type="submit">Save</button>
       <button type="submit" name="action" value="delete">Delete</button>
     </form>
@@ -49,6 +50,7 @@ function toggleAddUser(){
       <label><input type="checkbox" name="privileges" value="aoi"> AOI Report</label>
       <label><input type="checkbox" name="privileges" value="analysis"> Data Analysis</label>
       <label><input type="checkbox" name="privileges" value="dashboard"> SPC Dashboard</label>
+      <label><input type="checkbox" name="privileges" value="c_suite"> C-suite</label>
       <button type="submit">Add</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- add `c_suite` user flag and treat it like admin for permissions
- replace hard-coded ADMIN checks with new `is_admin` context flag
- expose C-suite role in settings UI so managers can view operator names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d2098870883259686d28cf7476998