### PR TITLE
Refactor AOI report page to use tabbed navigation

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -198,6 +198,34 @@ table thead th {
   justify-content: center;
 }
 
+/* Tab navigation */
+.tab-nav {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.tab-nav button {
+  background: var(--color-accent);
+  color: var(--color-white);
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.tab-nav button.active {
+  background: var(--color-black);
+  color: var(--color-white);
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
 .home-title img {
     background-color: var(--color-black);
     padding: 5px;

--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const links = document.querySelectorAll('.tab-link');
+  const contents = document.querySelectorAll('.tab-content');
+  links.forEach(link => {
+    link.addEventListener('click', () => {
+      links.forEach(l => l.classList.remove('active'));
+      contents.forEach(c => c.classList.remove('active'));
+      link.classList.add('active');
+      const target = document.getElementById(link.dataset.tab);
+      if (target) target.classList.add('active');
+    });
+  });
+});

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -11,123 +11,134 @@
   <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
 {% endblock %}
 {% block content %}
   <a href="/">← Home</a>
   <h1>AOI Daily Report</h1>
   <div id="container">
     <div id="aoi-actions">
-      <div class="action-panel">
-        {% if is_admin or permissions['aoi'] %}
-        <div class="action-card collapsible-card">
-          <h2 class="collapsible-header">Add New Entry</h2>
-          <div class="collapsible-content">
-          <form method="post">
-            <label>Report Date
-              <input type="date" name="report_date" required>
-            </label><br>
-            <label>Shift
-              <select name="shift" required>
-                <option value="1st">1st</option>
-                <option value="2nd">2nd</option>
-              </select>
-            </label><br>
-            <label>Operator
-              <input type="text" name="operator" required>
-            </label><br>
-            <label>Customer
-              <input type="text" name="customer">
-            </label><br>
-            <label>Assembly
-              <input type="text" name="assembly">
-            </label><br>
-            <label>Quantity Inspected
-              <input type="number" name="qty_inspected" min="0">
-            </label><br>
-            <label>Quantity Rejected
-              <input type="number" name="qty_rejected" min="0">
-            </label><br>
-            <label>Additional Information
-              <input type="text" name="additional_info">
-            </label><br>
-            <button type="submit">Add</button>
-          </form>
+      <nav class="tab-nav">
+        <button class="tab-link active" data-tab="add-entry">Add Entry</button>
+        <button class="tab-link" data-tab="analysis">AOI Analysis</button>
+        <button class="tab-link" data-tab="sql">SQL</button>
+      </nav>
+      <div id="add-entry" class="tab-content active">
+        <div class="action-panel">
+          {% if is_admin or permissions['aoi'] %}
+          <div class="action-card">
+            <h2>Add New Entry</h2>
+            <form method="post">
+              <label>Report Date
+                <input type="date" name="report_date" required>
+              </label><br>
+              <label>Shift
+                <select name="shift" required>
+                  <option value="1st">1st</option>
+                  <option value="2nd">2nd</option>
+                </select>
+              </label><br>
+              <label>Operator
+                <input type="text" name="operator" required>
+              </label><br>
+              <label>Customer
+                <input type="text" name="customer">
+              </label><br>
+              <label>Assembly
+                <input type="text" name="assembly">
+              </label><br>
+              <label>Quantity Inspected
+                <input type="number" name="qty_inspected" min="0">
+              </label><br>
+              <label>Quantity Rejected
+                <input type="number" name="qty_rejected" min="0">
+              </label><br>
+              <label>Additional Information
+                <input type="text" name="additional_info">
+              </label><br>
+              <button type="submit">Add</button>
+            </form>
           </div>
-        </div>
-        <div class="action-card collapsible-card">
-          <h2 class="collapsible-header">Bulk Upload</h2>
-          <div class="collapsible-content">
-          <form method="post" enctype="multipart/form-data">
-            <label>Report Date
-              <input type="date" name="report_date" required>
-            </label><br>
-            <label>Shift
-              <select name="shift" required>
-                <option value="1st">1st</option>
-                <option value="2nd">2nd</option>
-              </select>
-            </label><br>
-            <label>Excel File
-              <input type="file" name="excel_file" accept=".xls,.xlsx" required>
-            </label><br>
-            <button type="submit">Upload</button>
-          </form>
+          <div class="action-card">
+            <h2>Bulk Upload</h2>
+            <form method="post" enctype="multipart/form-data">
+              <label>Report Date
+                <input type="date" name="report_date" required>
+              </label><br>
+              <label>Shift
+                <select name="shift" required>
+                  <option value="1st">1st</option>
+                  <option value="2nd">2nd</option>
+                </select>
+              </label><br>
+              <label>Excel File
+                <input type="file" name="excel_file" accept=".xls,.xlsx" required>
+              </label><br>
+              <button type="submit">Upload</button>
+            </form>
           </div>
+          {% endif %}
         </div>
-        {% endif %}
-        <div class="action-card">
-          <h2>Data Mining Filters</h2>
-          <form method="get" action="/aoi">
-            <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label><br>
-            <label>End: <input type="date" name="end" value="{{ end or '' }}"></label><br>
-            <label>Customer:
-              <select name="customer">
-                <option value="">All</option>
-                {% for c in customers %}
-                <option value="{{ c }}" {% if c == selected_customer %}selected{% endif %}>{{ c }}</option>
-                {% endfor %}
-              </select>
-            </label><br>
-            <label>Shift:
-              <select name="shift">
-                <option value="">All</option>
-                {% for s in shifts %}
-                <option value="{{ s }}" {% if s == selected_shift %}selected{% endif %}>{{ s }}</option>
-                {% endfor %}
-              </select>
-            </label><br>
-            <button type="submit">Apply</button>
-          </form>
+      </div>
+      <div id="analysis" class="tab-content">
+        <div class="action-panel">
+          <div class="action-card">
+            <h2>Data Mining Filters</h2>
+            <form method="get" action="/aoi">
+              <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label><br>
+              <label>End: <input type="date" name="end" value="{{ end or '' }}"></label><br>
+              <label>Customer:
+                <select name="customer">
+                  <option value="">All</option>
+                  {% for c in customers %}
+                  <option value="{{ c }}" {% if c == selected_customer %}selected{% endif %}>{{ c }}</option>
+                  {% endfor %}
+                </select>
+              </label><br>
+              <label>Shift:
+                <select name="shift">
+                  <option value="">All</option>
+                  {% for s in shifts %}
+                  <option value="{{ s }}" {% if s == selected_shift %}selected{% endif %}>{{ s }}</option>
+                  {% endfor %}
+                </select>
+              </label><br>
+              <button type="submit">Apply</button>
+            </form>
+          </div>
+          <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators">Expand</button></h2>
+          <canvas id="operatorsChart"></canvas>
+          <h2>Shift Totals <button class="expand-chart" data-chart="shift">Expand</button></h2>
+          <canvas id="shiftChart"></canvas>
+          <h2>Operator Reject Rates <button class="expand-chart" data-chart="customer">Expand</button></h2>
+          <canvas id="customerChart"></canvas>
+          <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield">Expand</button></h2>
+          <canvas id="yieldChart"></canvas>
+          <h2>Assembly Performance</h2>
+          <table id="assemblyTable">
+            <thead>
+              <tr>
+                <th>Assembly</th>
+                <th>Inspected</th>
+                <th>Rejected</th>
+                <th>Yield</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in assemblies %}
+              <tr>
+                <td>{{ row['assembly'] }}</td>
+                <td>{{ row['inspected'] }}</td>
+                <td>{{ row['rejected'] }}</td>
+                <td>{{ '{:.2%}'.format(row['yield']) }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
-        <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators">Expand</button></h2>
-        <canvas id="operatorsChart"></canvas>
-        <h2>Shift Totals <button class="expand-chart" data-chart="shift">Expand</button></h2>
-        <canvas id="shiftChart"></canvas>
-        <h2>Operator Reject Rates <button class="expand-chart" data-chart="customer">Expand</button></h2>
-        <canvas id="customerChart"></canvas>
-        <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield">Expand</button></h2>
-        <canvas id="yieldChart"></canvas>
-        <h2>Assembly Performance</h2>
-        <table id="assemblyTable">
-          <thead>
-            <tr>
-              <th>Assembly</th>
-              <th>Inspected</th>
-              <th>Rejected</th>
-              <th>Yield</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for row in assemblies %}
-            <tr>
-              <td>{{ row['assembly'] }}</td>
-              <td>{{ row['inspected'] }}</td>
-              <td>{{ row['rejected'] }}</td>
-              <td>{{ '{:.2%}'.format(row['yield']) }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+      </div>
+      <div id="sql" class="tab-content">
+        <div id="sql-content"></div>
       </div>
     </div>
     <div id="divider"></div>


### PR DESCRIPTION
## Summary
- Replace collapsible panels on AOI page with `<nav>` tabs for Add Entry, AOI Analysis and SQL
- Style new tab system and add JavaScript for switching between tabs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d22af50148325a037bb339ee8621a