### PR TITLE
Add operator and assembly filters to AOI report

### DIFF
--- a/run.py
+++ b/run.py
@@ -528,14 +528,12 @@ def aoi_report():
         return redirect(url_for('aoi_report'))
 
     # GET: fetch rows and analytics
-    rows = conn.execute(
-        'SELECT * FROM aoi_reports ORDER BY report_date DESC, id DESC'
-    ).fetchall()
-
     start = request.args.get('start')
     end = request.args.get('end')
     customer = request.args.get('customer')
     shift_filter = request.args.get('shift')
+    operator_filter = request.args.get('operator')
+    assembly_filter = request.args.get('assembly')
 
     where = 'WHERE 1=1'
     params = []
@@ -551,6 +549,17 @@ def aoi_report():
     if shift_filter:
         where += ' AND shift = ?'
         params.append(shift_filter)
+    if operator_filter:
+        where += ' AND operator = ?'
+        params.append(operator_filter)
+    if assembly_filter:
+        where += ' AND assembly = ?'
+        params.append(assembly_filter)
+
+    rows = conn.execute(
+        f'SELECT * FROM aoi_reports {where} ORDER BY report_date DESC, id DESC',
+        params,
+    ).fetchall()
 
     op_rows = conn.execute(
         f'SELECT operator, SUM(qty_inspected) AS inspected, SUM(qty_rejected) AS rejected '
@@ -580,6 +589,8 @@ def aoi_report():
     ).fetchall()
     customer_opts = [r['customer'] for r in conn.execute('SELECT DISTINCT customer FROM aoi_reports ORDER BY customer').fetchall()]
     shift_opts = [r['shift'] for r in conn.execute('SELECT DISTINCT shift FROM aoi_reports ORDER BY shift').fetchall()]
+    operator_opts = [r['operator'] for r in conn.execute('SELECT DISTINCT operator FROM aoi_reports ORDER BY operator').fetchall()]
+    assembly_opts = [r['assembly'] for r in conn.execute('SELECT DISTINCT assembly FROM aoi_reports ORDER BY assembly').fetchall()]
     conn.close()
 
     operators = []
@@ -642,10 +653,14 @@ def aoi_report():
         yield_series=yield_series,
         customers=customer_opts,
         shifts=shift_opts,
+        operator_opts=operator_opts,
+        assembly_opts=assembly_opts,
         start=start,
         end=end,
         selected_customer=customer,
         selected_shift=shift_filter,
+        selected_operator=operator_filter,
+        selected_assembly=assembly_filter,
     )
 
 

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -96,6 +96,22 @@
                 {% endfor %}
               </select>
             </label><br>
+            <label>Operator:
+              <select name="operator">
+                <option value="">All</option>
+                {% for o in operator_opts %}
+                <option value="{{ o }}" {% if o == selected_operator %}selected{% endif %}>{{ o }}</option>
+                {% endfor %}
+              </select>
+            </label><br>
+            <label>Assembly:
+              <select name="assembly">
+                <option value="">All</option>
+                {% for a in assembly_opts %}
+                <option value="{{ a }}" {% if a == selected_assembly %}selected{% endif %}>{{ a }}</option>
+                {% endfor %}
+              </select>
+            </label><br>
             <button type="submit">Apply</button>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- Allow filtering AOI report by operator and assembly
- Populate operator and assembly filter options from database
- Apply combined filters to table and analytics queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d22d23058832582e0d88e42c72c09