### PR TITLE
Add SQL query endpoint and AOI operator/assembly filters

### DIFF
--- a/run.py
+++ b/run.py
@@ -14,6 +14,7 @@ import os
 import sqlite3
 import pandas as pd
 from datetime import datetime, timedelta
+import re
 
 def parse_aoi_rows(path: str):
     """Return rows from an AOI Excel file without headers."""
@@ -528,14 +529,12 @@ def aoi_report():
         return redirect(url_for('aoi_report'))
 
     # GET: fetch rows and analytics
-    rows = conn.execute(
-        'SELECT * FROM aoi_reports ORDER BY report_date DESC, id DESC'
-    ).fetchall()
-
     start = request.args.get('start')
     end = request.args.get('end')
     customer = request.args.get('customer')
     shift_filter = request.args.get('shift')
+    operator_filter = request.args.get('operator')
+    assembly_filter = request.args.get('assembly')
 
     where = 'WHERE 1=1'
     params = []
@@ -551,6 +550,17 @@ def aoi_report():
     if shift_filter:
         where += ' AND shift = ?'
         params.append(shift_filter)
+    if operator_filter:
+        where += ' AND operator = ?'
+        params.append(operator_filter)
+    if assembly_filter:
+        where += ' AND assembly = ?'
+        params.append(assembly_filter)
+
+    rows = conn.execute(
+        f'SELECT * FROM aoi_reports {where} ORDER BY report_date DESC, id DESC',
+        params,
+    ).fetchall()
 
     op_rows = conn.execute(
         f'SELECT operator, SUM(qty_inspected) AS inspected, SUM(qty_rejected) AS rejected '
@@ -580,6 +590,8 @@ def aoi_report():
     ).fetchall()
     customer_opts = [r['customer'] for r in conn.execute('SELECT DISTINCT customer FROM aoi_reports ORDER BY customer').fetchall()]
     shift_opts = [r['shift'] for r in conn.execute('SELECT DISTINCT shift FROM aoi_reports ORDER BY shift').fetchall()]
+    operator_opts = [r['operator'] for r in conn.execute('SELECT DISTINCT operator FROM aoi_reports ORDER BY operator').fetchall()]
+    assembly_opts = [r['assembly'] for r in conn.execute('SELECT DISTINCT assembly FROM aoi_reports ORDER BY assembly').fetchall()]
     conn.close()
 
     operators = []
@@ -642,11 +654,46 @@ def aoi_report():
         yield_series=yield_series,
         customers=customer_opts,
         shifts=shift_opts,
+        operator_opts=operator_opts,
+        assembly_opts=assembly_opts,
         start=start,
         end=end,
         selected_customer=customer,
         selected_shift=shift_filter,
+        selected_operator=operator_filter,
+        selected_assembly=assembly_filter,
     )
+
+
+@app.route('/aoi/sql', methods=['POST'])
+@login_required
+def aoi_sql():
+    if not has_permission('aoi'):
+        return jsonify(error='Forbidden'), 403
+    data = request.get_json() or {}
+    query = data.get('query', '')
+    params = data.get('params', [])
+    if not isinstance(params, list):
+        return jsonify(error='Invalid parameters'), 400
+    statements = [s.strip() for s in query.split(';') if s.strip()]
+    if len(statements) != 1 or not statements[0].lower().startswith('select'):
+        return jsonify(error='Only SELECT statements allowed'), 400
+    lowered = statements[0].lower()
+    allowed_tables = {'aoi_reports'}
+    pattern = re.compile(r'from\s+([a-zA-Z0-9_]+)|join\s+([a-zA-Z0-9_]+)')
+    for m in pattern.finditer(lowered):
+        tbl = m.group(1) or m.group(2)
+        if tbl not in allowed_tables:
+            return jsonify(error='Table not allowed'), 400
+    conn = get_db()
+    try:
+        cur = conn.execute(statements[0], params)
+        rows = [dict(r) for r in cur.fetchall()]
+    except Exception as e:
+        conn.close()
+        return jsonify(error=str(e)), 400
+    conn.close()
+    return jsonify(rows=rows)
 
 
 @app.route('/aoi/<int:row_id>', methods=['DELETE'])

--- a/static/js/aoi_sql.js
+++ b/static/js/aoi_sql.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('sql-form');
+  if (!form) return;
+  const queryInput = document.getElementById('sql-query');
+  const table = document.getElementById('sql-results');
+  const thead = table.querySelector('thead');
+  const tbody = table.querySelector('tbody');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const query = queryInput.value;
+    try {
+      const resp = await fetch('/aoi/sql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+      });
+      const data = await resp.json();
+      if (!resp.ok || data.error) {
+        thead.innerHTML = '';
+        tbody.innerHTML = `<tr><td>${data.error || 'Error executing query'}</td></tr>`;
+        return;
+      }
+      const rows = data.rows || [];
+      if (!rows.length) {
+        thead.innerHTML = '';
+        tbody.innerHTML = '<tr><td>No results</td></tr>';
+        return;
+      }
+      const cols = Object.keys(rows[0]);
+      thead.innerHTML = '<tr>' + cols.map(c => `<th>${c}</th>`).join('') + '</tr>';
+      tbody.innerHTML = rows.map(r => {
+        return '<tr>' + cols.map(c => `<td>${r[c]}</td>`).join('') + '</tr>';
+      }).join('');
+    } catch (err) {
+      thead.innerHTML = '';
+      tbody.innerHTML = `<tr><td>${err}</td></tr>`;
+    }
+  });
+});

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -12,6 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/aoi_sql.js') }}" defer></script>
 {% endblock %}
 {% block content %}
   <a href="/">← Home</a>
@@ -103,6 +104,22 @@
                   {% endfor %}
                 </select>
               </label><br>
+              <label>Operator:
+                <select name="operator">
+                  <option value="">All</option>
+                  {% for o in operator_opts %}
+                  <option value="{{ o }}" {% if o == selected_operator %}selected{% endif %}>{{ o }}</option>
+                  {% endfor %}
+                </select>
+              </label><br>
+              <label>Assembly:
+                <select name="assembly">
+                  <option value="">All</option>
+                  {% for a in assembly_opts %}
+                  <option value="{{ a }}" {% if a == selected_assembly %}selected{% endif %}>{{ a }}</option>
+                  {% endfor %}
+                </select>
+              </label><br>
               <button type="submit">Apply</button>
             </form>
           </div>
@@ -138,7 +155,19 @@
         </div>
       </div>
       <div id="sql" class="tab-content">
-        <div id="sql-content"></div>
+        <div class="action-panel">
+          <div class="action-card">
+            <h2>Run SQL Query</h2>
+            <form id="sql-form">
+              <textarea id="sql-query" rows="5" cols="60"></textarea><br>
+              <button type="submit">Execute</button>
+            </form>
+            <table id="sql-results">
+              <thead></thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </div>
     <div id="divider"></div>


### PR DESCRIPTION
## Summary
- Add server-side SQL endpoint with permission checks and table whitelist
- Expose operator and assembly filters in AOI analytics and main table
- Wire up SQL tab in UI with form and JavaScript fetch to display results

## Testing
- `python -m py_compile run.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d25b235688325a3d03178d18a7e4e