### PR TITLE
Add Docs link to topbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
   {% if current_user %}
   <div class="topbar">
     <span class="user-label">user:{{ current_user }}</span>
+    <a href="{{ url_for('docs') }}">Docs</a>
     <a href="{{ url_for('logout') }}">Logout</a>
     <button id="theme-toggle" type="button">Dark Mode</button>
     {% if is_admin %}


### PR DESCRIPTION
## Summary
- Add Docs link to global top bar visible to authenticated users

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2c4edfc48325880bbfe281986817