### PR TITLE
Fix part number search in verified markings table

### DIFF
--- a/static/js/part_markings.js
+++ b/static/js/part_markings.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let target = null;
     rows.forEach(row => {
       row.classList.remove('highlight');
-      const cell = row.cells[row.cells.length - 1]; // Part Number column
+      const cell = row.querySelector('.part-number');
       if (cell && cell.textContent.trim() === term) {
         target = row;
       }

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -77,7 +77,7 @@
             <td>{{ row['manufacturer'] }}</td>
             <td>{{ row['mfg_number2'] }}</td>
             <td>{{ row['mfg_number1'] }}</td>
-            <td>{{ row['part_number'] }}</td>
+            <td class="part-number">{{ row['part_number'] }}</td>
             {% if is_admin or permissions['part_markings'] %}
             <td class="no-edit"><button type="button" class="delete-row" title="Delete row">Delete</button></td>
             {% endif %}


### PR DESCRIPTION
## Summary
- mark the part number cell with a dedicated `part-number` class
- search by `.part-number` instead of assuming the last table column

## Testing
- `pytest -q`
- Python simulation verifying search highlights correct row with and without Actions column

------
https://chatgpt.com/codex/tasks/task_e_689dc8b1019c832581c03706b7f3f4aa