### PR TITLE
Add model name filter for TH/SMT

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -32,6 +32,24 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  // Model filter for MOAT table
+  const modelFilter = document.getElementById('model-filter');
+  if (modelFilter) {
+    modelFilter.addEventListener('change', () => {
+      const value = modelFilter.value;
+      const rows = document.querySelectorAll('#moat-table tbody tr');
+      rows.forEach(row => {
+        const name = row.cells[0].textContent.toUpperCase();
+        const show =
+          value === 'all' ||
+          (value === 'smt' && name.includes('SMT')) ||
+          (value === 'th' && name.includes('TH'));
+        row.style.display = show ? '' : 'none';
+      });
+    });
+    modelFilter.dispatchEvent(new Event('change'));
+  }
+
   function setupLineSelectors(prefix) {
     const selects = [];
     const ands = [];

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -162,6 +162,14 @@
       </div>
       <div id="divider"></div>
       <div id="moat-table">
+        <div id="model-filter-container">
+          <label for="model-filter">Show Models</label>
+          <select id="model-filter">
+            <option value="all">All</option>
+            <option value="smt">SMT</option>
+            <option value="th">TH</option>
+          </select>
+        </div>
         <table>
           <thead><tr>
             <th>Model Name</th><th>Total Boards</th><th>Total Parts/Board</th>

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -54,7 +54,7 @@
       <p>Analyze MOAT and AOI data for trends.</p>
       <ol>
         <li>Go to the <strong>Analysis</strong> page.</li>
-        <li>Filter data or upload files for processing.</li>
+        <li>Filter data or upload files for processing. Use the model filter to view all models or only those with 'TH' or 'SMT' in the name.</li>
         <li>Inspect tables and charts for insights.</li>
       </ol>
       <a href="#top">Back to top</a>


### PR DESCRIPTION
## Summary
- Add dropdown to filter MOAT table by SMT or TH model names
- Implement client-side logic to show/hide rows based on selection
- Document model filter on Analysis page docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de180974883259f2aca365ceb3e8b