### PR TITLE
Add searchable model name dropdown for control charts

### DIFF
--- a/run.py
+++ b/run.py
@@ -770,6 +770,10 @@ def analysis():
         rows = []
         total_rows = 0
         earliest = latest = ''
+    conn = get_db()
+    model_rows = conn.execute('SELECT DISTINCT model_name FROM moat ORDER BY model_name').fetchall()
+    conn.close()
+    model_names = [r['model_name'] for r in model_rows]
 
     return render_template(
         'analysis.html',
@@ -777,7 +781,8 @@ def analysis():
         show_moat=show,
         total_rows=total_rows,
         earliest=earliest,
-        latest=latest
+        latest=latest,
+        model_names=model_names
     )
 
 @app.route('/analysis/chart-data')

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -53,8 +53,8 @@
               <label>Min Boards
                 <input type="number" id="min-boards" value="7" title="Minimum boards required">
               </label><br>
-              <label>Model Names
-                <input type="text" id="model-names" placeholder="ModelA,ModelB" title="Comma-separated model names">
+              <label>Model Name
+                <input list="model-list" id="model-names" placeholder="Start typing..." title="Select model name">
               </label><br>
               <label>Lines
                 <select id="line-select-1">
@@ -114,8 +114,8 @@
               <label>Min Boards
                 <input type="number" id="ng-min-boards" value="7" title="Minimum boards required">
               </label><br>
-              <label>Model Names
-                <input type="text" id="ng-model-names" placeholder="ModelA,ModelB" title="Comma-separated model names">
+              <label>Model Name
+                <input list="model-list" id="ng-model-names" placeholder="Start typing..." title="Select model name">
               </label><br>
               <label>Lines
                 <select id="ng-line-select-1">
@@ -160,6 +160,11 @@
           </div>
         </div>
       </div>
+      <datalist id="model-list">
+        {% for name in model_names %}
+        <option value="{{ name }}"></option>
+        {% endfor %}
+      </datalist>
       <div id="divider"></div>
       <div id="moat-table">
         <div id="model-filter-container">


### PR DESCRIPTION
## Summary
- Provide dropdown search for model names in control chart settings
- Supply unique model names from database to populate dropdown

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689de8f69e5c8325a63514b5aa8f6be7