### PR TITLE
Allow multiple model selection and auto bar chart

### DIFF
--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -54,7 +54,13 @@
                 <input type="number" id="min-boards" value="7" title="Minimum boards required">
               </label><br>
               <label>Model Name
-                <input list="model-list" id="model-names" placeholder="Start typing..." title="Select model name">
+                <input list="model-list" id="model-name-1" placeholder="Start typing..." title="Select model name">
+                <span id="model-name-and-2" style="display:none">and</span>
+                <input list="model-list" id="model-name-2" style="display:none" placeholder="Start typing..." title="Select model name">
+                <span id="model-name-and-3" style="display:none">and</span>
+                <input list="model-list" id="model-name-3" style="display:none" placeholder="Start typing..." title="Select model name">
+                <span id="model-name-and-4" style="display:none">and</span>
+                <input list="model-list" id="model-name-4" style="display:none" placeholder="Start typing..." title="Select model name">
               </label><br>
               <label>Lines
                 <select id="line-select-1">
@@ -115,7 +121,13 @@
                 <input type="number" id="ng-min-boards" value="7" title="Minimum boards required">
               </label><br>
               <label>Model Name
-                <input list="model-list" id="ng-model-names" placeholder="Start typing..." title="Select model name">
+                <input list="model-list" id="ng-model-name-1" placeholder="Start typing..." title="Select model name">
+                <span id="ng-model-name-and-2" style="display:none">and</span>
+                <input list="model-list" id="ng-model-name-2" style="display:none" placeholder="Start typing..." title="Select model name">
+                <span id="ng-model-name-and-3" style="display:none">and</span>
+                <input list="model-list" id="ng-model-name-3" style="display:none" placeholder="Start typing..." title="Select model name">
+                <span id="ng-model-name-and-4" style="display:none">and</span>
+                <input list="model-list" id="ng-model-name-4" style="display:none" placeholder="Start typing..." title="Select model name">
               </label><br>
               <label>Lines
                 <select id="ng-line-select-1">


### PR DESCRIPTION
## Summary
- allow adding multiple model names for FC and NG control charts
- automatically switch to bar chart when only one model is plotted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689df28df70c832588322f6e8388e083