### PR TITLE
Add SQL query support for MOAT analysis

### DIFF
--- a/static/js/moat_sql.js
+++ b/static/js/moat_sql.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('sql-form');
+  if (!form) return;
+  const queryInput = document.getElementById('sql-query');
+  const table = document.getElementById('sql-results');
+  const thead = table.querySelector('thead');
+  const tbody = table.querySelector('tbody');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const query = queryInput.value;
+    try {
+      const resp = await fetch('/moat/sql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+      });
+      const data = await resp.json();
+      if (!resp.ok || data.error) {
+        thead.innerHTML = '';
+        tbody.innerHTML = `<tr><td>${data.error || 'Error executing query'}</td></tr>`;
+        return;
+      }
+      const rows = data.rows || [];
+      if (!rows.length) {
+        thead.innerHTML = '';
+        tbody.innerHTML = '<tr><td>No results</td></tr>';
+        return;
+      }
+      const cols = Object.keys(rows[0]);
+      thead.innerHTML = '<tr>' + cols.map(c => `<th>${c}</th>`).join('') + '</tr>';
+      tbody.innerHTML = rows.map(r => {
+        return '<tr>' + cols.map(c => `<td>${r[c]}</td>`).join('') + '</tr>';
+      }).join('');
+    } catch (err) {
+      thead.innerHTML = '';
+      tbody.innerHTML = `<tr><td>${err}</td></tr>`;
+    }
+  });
+});

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -2,9 +2,10 @@
 {% block title %}Data Analysis - PPM MOAT & Control Chart{% endblock %}
 {% block head_extra %}
   <!-- Chart.js for control chart rendering -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
-  <script src="/static/js/analysis.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+    <script src="/static/js/analysis.js" defer></script>
+    <script src="{{ url_for('static', filename='js/moat_sql.js') }}" defer></script>
 {% endblock %}
 {% block content %}
   <a href="/">← Home</a>
@@ -169,6 +170,17 @@
               <p class="field-desc">Generate the chart using the selected parameters.</p>
               <button id="run-ng-chart-btn" title="Generate NG control chart">Run Chart</button>
             </div>
+          </div>
+          <div class="action-card">
+            <h2>Run SQL Query</h2>
+            <form id="sql-form">
+              <textarea id="sql-query" rows="5" cols="60"></textarea><br>
+              <button type="submit">Execute</button>
+            </form>
+            <table id="sql-results">
+              <thead></thead>
+              <tbody></tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -55,6 +55,7 @@
       <ol>
         <li>Go to the <strong>Analysis</strong> page.</li>
         <li>Inspect tables and charts for insights.</li>
+        <li>Use the <strong>Run SQL Query</strong> card to execute SELECT statements on the MOAT table.</li>
       </ol>
       <a href="#top">Back to top</a>
     </div>

--- a/tests/test_moat_sql.py
+++ b/tests/test_moat_sql.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from run import app, init_db, get_db
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, analysis) VALUES (?,?,1)",
+        ('tester', 'pw')
+    )
+    conn.execute(
+        "INSERT INTO moat (model_name, total_boards, total_parts_per_board, total_parts, ng_parts, ng_ppm, falsecall_parts, falsecall_ppm, upload_time) VALUES (?,?,?,?,?,?,?,?,?)",
+        ('MODEL1', 1, 1, 1, 0, 0.0, 0, 0.0, '2023-01-01T00:00:00')
+    )
+    conn.commit()
+    conn.close()
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user'] = 'tester'
+        yield client
+
+
+def test_moat_sql_select(client):
+    resp = client.post('/moat/sql', json={'query': 'SELECT model_name FROM moat'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['rows'][0]['model_name'] == 'MODEL1'
+
+
+def test_moat_sql_reject_nonselect(client):
+    resp = client.post('/moat/sql', json={'query': 'DELETE FROM moat'})
+    assert resp.status_code == 400
+
+
+def test_moat_sql_reject_other_tables(client):
+    resp = client.post('/moat/sql', json={'query': 'SELECT * FROM users'})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Allow analysis users to run SELECT queries on MOAT data via new `/moat/sql` endpoint
- Add MOAT SQL query form and client-side script to analysis page
- Document SQL querying capability for MOAT and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689df608aa60832585143448c22081cc