### PR TITLE
Add control chart summaries and include table in PDF

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -312,8 +312,12 @@ window.addEventListener('DOMContentLoaded', () => {
               tbody.appendChild(tr);
             });
           }
+          const entryCount = data.length;
+          const totalBoards = data.reduce((sum, r) => sum + r.boards, 0);
+          const totalFalseCalls = data.reduce((sum, r) => sum + r.rate * r.boards, 0);
+          const avgRate = totalBoards ? totalFalseCalls / totalBoards : 0;
           const dateText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
-          document.getElementById('fc-chart-date-range').textContent = `${dateText} | Lines: ${lineText}`;
+          document.getElementById('fc-chart-date-range').textContent = `${dateText} | Lines: ${lineText} | Entries: ${entryCount} | Avg FC Rate: ${avgRate.toFixed(2)}`;
           chartModal.style.display = 'block';
         });
     });
@@ -334,6 +338,8 @@ window.addEventListener('DOMContentLoaded', () => {
       const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
       const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
       pdf.addImage(imgData, 'PNG', 10, 30, pdfWidth, pdfHeight);
+      pdf.addPage('portrait');
+      pdf.autoTable({ html: '#fc-data-table', startY: 10 });
       pdf.save('fc-control-chart.pdf');
     });
   }
@@ -433,8 +439,12 @@ window.addEventListener('DOMContentLoaded', () => {
               tbody.appendChild(tr);
             });
           }
+          const entryCount = data.length;
+          const totalBoards = data.reduce((sum, r) => sum + r.boards, 0);
+          const totalNg = data.reduce((sum, r) => sum + r.rate * r.boards, 0);
+          const avgRate = totalBoards ? totalNg / totalBoards : 0;
           const dateText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
-          document.getElementById('ng-chart-date-range').textContent = `${dateText} | Lines: ${lineText}`;
+          document.getElementById('ng-chart-date-range').textContent = `${dateText} | Lines: ${lineText} | Entries: ${entryCount} | Avg NG Rate: ${avgRate.toFixed(3)}`;
           chartNgModal.style.display = 'block';
         });
     });
@@ -455,6 +465,8 @@ window.addEventListener('DOMContentLoaded', () => {
       const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
       const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
       pdf.addImage(imgData, 'PNG', 10, 30, pdfWidth, pdfHeight);
+      pdf.addPage('portrait');
+      pdf.autoTable({ html: '#ng-data-table', startY: 10 });
       pdf.save('ng-control-chart.pdf');
     });
   }

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -4,6 +4,7 @@
   <!-- Chart.js for control chart rendering -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
     <script src="/static/js/analysis.js" defer></script>
     <script src="{{ url_for('static', filename='js/moat_sql.js') }}" defer></script>
 {% endblock %}

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -57,6 +57,7 @@
         <li>Inspect tables and charts for insights.</li>
         <li>Use the <strong>Run SQL Query</strong> card to execute SELECT statements on the MOAT table.</li>
       </ol>
+      <p>Control charts display the number of entries and overall average rates. Downloading a chart now produces a PDF with the chart on the first page and the data table on subsequent pages.</p>
       <a href="#top">Back to top</a>
     </div>
 


### PR DESCRIPTION
## Summary
- Display entry count and overall average rates alongside selected date range and lines for control charts.
- Exported control chart PDFs now include the data table on subsequent pages after the chart.
- Documented the enhanced control chart features.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e0cba01888325a7dc8992c1de17b8