### PR TITLE
Add AOI report summaries with charts and PDF export

### DIFF
--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -10,6 +10,7 @@
   <script id="customer-data" type="application/json">{{ customer_rates|tojson }}</script>
   <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_sql.js') }}" defer></script>
@@ -22,6 +23,7 @@
       <nav class="tab-nav">
         <button class="tab-link active" data-tab="add-entry">Add Entry</button>
         <button class="tab-link" data-tab="analysis">AOI Analysis</button>
+        <button class="tab-link" data-tab="reports">Reports</button>
         <button class="tab-link" data-tab="sql">SQL</button>
       </nav>
       <div id="add-entry" class="tab-content active">
@@ -152,6 +154,68 @@
               {% endfor %}
             </tbody>
           </table>
+        </div>
+      </div>
+      <div id="reports" class="tab-content">
+        <div class="action-panel">
+          <nav class="subtab-nav">
+            <button class="subtab-link active" data-subtab="daily">Daily</button>
+            <button class="subtab-link" data-subtab="weekly">Weekly</button>
+            <button class="subtab-link" data-subtab="monthly">Monthly</button>
+            <button class="subtab-link" data-subtab="yearly">Yearly</button>
+          </nav>
+          <div id="daily" class="subtab-content active">
+            <h2>Daily Summary <button class="download-report" data-period="daily">Download PDF</button></h2>
+            <canvas id="daily-operators"></canvas>
+            <canvas id="daily-shift"></canvas>
+            <canvas id="daily-reject"></canvas>
+            <canvas id="daily-yield"></canvas>
+            <table id="daily-table">
+              <thead>
+                <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div id="weekly" class="subtab-content">
+            <h2>Weekly Summary <button class="download-report" data-period="weekly">Download PDF</button></h2>
+            <canvas id="weekly-operators"></canvas>
+            <canvas id="weekly-shift"></canvas>
+            <canvas id="weekly-reject"></canvas>
+            <canvas id="weekly-yield"></canvas>
+            <table id="weekly-table">
+              <thead>
+                <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div id="monthly" class="subtab-content">
+            <h2>Monthly Summary <button class="download-report" data-period="monthly">Download PDF</button></h2>
+            <canvas id="monthly-operators"></canvas>
+            <canvas id="monthly-shift"></canvas>
+            <canvas id="monthly-reject"></canvas>
+            <canvas id="monthly-yield"></canvas>
+            <table id="monthly-table">
+              <thead>
+                <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div id="yearly" class="subtab-content">
+            <h2>Yearly Summary <button class="download-report" data-period="yearly">Download PDF</button></h2>
+            <canvas id="yearly-operators"></canvas>
+            <canvas id="yearly-shift"></canvas>
+            <canvas id="yearly-reject"></canvas>
+            <canvas id="yearly-yield"></canvas>
+            <table id="yearly-table">
+              <thead>
+                <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
         </div>
       </div>
       <div id="sql" class="tab-content">

--- a/tests/test_aoi_report.py
+++ b/tests/test_aoi_report.py
@@ -1,9 +1,10 @@
 import os
 import sys
 import pandas as pd
+import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from run import parse_aoi_rows
+from run import parse_aoi_rows, app, init_db, get_db
 
 
 def test_parse_aoi_rows(tmp_path):
@@ -16,3 +17,40 @@ def test_parse_aoi_rows(tmp_path):
     rows = parse_aoi_rows(str(file))
     assert rows[0]['operator'] == 'Alice'
     assert rows[1]['qty_rejected'] == 2
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, aoi) VALUES (?,?,1)",
+        ('tester', 'pw')
+    )
+    data = [
+        ('2024-01-01', '1st', 'Alice', 'Cust1', 'Asm1', 10, 1, ''),
+        ('2024-01-02', '1st', 'Alice', 'Cust1', 'Asm1', 15, 0, ''),
+        ('2024-01-01', '2nd', 'Bob', 'Cust2', 'Asm2', 20, 2, ''),
+    ]
+    conn.executemany(
+        "INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?)",
+        data,
+    )
+    conn.commit()
+    conn.close()
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user'] = 'tester'
+        yield client
+
+
+def test_aoi_report_data_daily(client):
+    resp = client.get('/aoi/report-data?freq=daily')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['operators'][0]['operator'] == 'Alice'
+    assert data['operators'][0]['inspected'] == 15
+    assert data['shift_totals'][0]['shift'] == '1st'
+    assert data['shift_totals'][0]['inspected'] == 15


### PR DESCRIPTION
## Summary
- Add Reports tab with daily/weekly/monthly/yearly summaries in AOI page
- Fetch aggregated AOI metrics per period and render charts with PDF download
- Provide `/aoi/report-data` endpoint and tests for reporting aggregation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2ad3dbc08325b3b0a7c0c3b03814