### PR TITLE
Scope tab navigation to local container

### DIFF
--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -1,13 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const links = document.querySelectorAll('.tab-link');
-  const contents = document.querySelectorAll('.tab-content');
-  links.forEach(link => {
-    link.addEventListener('click', () => {
-      links.forEach(l => l.classList.remove('active'));
-      contents.forEach(c => c.classList.remove('active'));
-      link.classList.add('active');
-      const target = document.getElementById(link.dataset.tab);
-      if (target) target.classList.add('active');
+  document.querySelectorAll('.tab-nav').forEach(nav => {
+    const links = nav.querySelectorAll('.tab-link');
+    const container = nav.parentElement;
+    const contents = Array.from(container.children).filter(el =>
+      el.classList.contains('tab-content')
+    );
+
+    links.forEach(link => {
+      link.addEventListener('click', () => {
+        links.forEach(l => l.classList.remove('active'));
+        contents.forEach(c => c.classList.remove('active'));
+        link.classList.add('active');
+        const target = container.querySelector(`#${link.dataset.tab}`);
+        if (target) target.classList.add('active');
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- refactor tab navigation script to iterate over each `.tab-nav` container
- ensure clicks only activate tabs within their own group and scope content queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2dcf0c7883259c311d8424872c20