### PR TITLE
Extract PDF export helper and reuse across charts

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -328,19 +328,13 @@ window.addEventListener('DOMContentLoaded', () => {
   if (downloadFcBtn) {
     downloadFcBtn.addEventListener('click', () => {
       if (!chartInstance) return;
-      const { jsPDF } = window.jspdf;
-      const pdf = new jsPDF({ orientation: 'landscape' });
-      pdf.text('Control Chart - Avg FalseCall Rate', 10, 10);
       const dateText = document.getElementById('fc-chart-date-range').textContent;
-      pdf.text(dateText, 10, 20);
-      const imgData = chartInstance.toBase64Image();
-      const imgProps = pdf.getImageProperties(imgData);
-      const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
-      const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
-      pdf.addImage(imgData, 'PNG', 10, 30, pdfWidth, pdfHeight);
-      pdf.addPage('portrait');
-      pdf.autoTable({ html: '#fc-data-table', startY: 10 });
-      pdf.save('fc-control-chart.pdf');
+      exportChartWithTable(
+        chartInstance,
+        '#fc-data-table',
+        ['Control Chart - Avg FalseCall Rate', dateText],
+        'fc-control-chart.pdf'
+      );
     });
   }
 
@@ -455,19 +449,13 @@ window.addEventListener('DOMContentLoaded', () => {
   if (downloadNgBtn) {
     downloadNgBtn.addEventListener('click', () => {
       if (!ngChartInstance) return;
-      const { jsPDF } = window.jspdf;
-      const pdf = new jsPDF({ orientation: 'landscape' });
-      pdf.text('Control Chart - Avg NG Rate', 10, 10);
       const dateText = document.getElementById('ng-chart-date-range').textContent;
-      pdf.text(dateText, 10, 20);
-      const imgData = ngChartInstance.toBase64Image();
-      const imgProps = pdf.getImageProperties(imgData);
-      const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
-      const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
-      pdf.addImage(imgData, 'PNG', 10, 30, pdfWidth, pdfHeight);
-      pdf.addPage('portrait');
-      pdf.autoTable({ html: '#ng-data-table', startY: 10 });
-      pdf.save('ng-control-chart.pdf');
+      exportChartWithTable(
+        ngChartInstance,
+        '#ng-data-table',
+        ['Control Chart - Avg NG Rate', dateText],
+        'ng-control-chart.pdf'
+      );
     });
   }
 
@@ -541,18 +529,13 @@ window.addEventListener('DOMContentLoaded', () => {
       btn.addEventListener('click', () => {
         const chart = reportCharts[freq];
         if (!chart) return;
-        const { jsPDF } = window.jspdf;
-        const pdf = new jsPDF({ orientation: 'landscape' });
         const title = `MOAT Report - ${freq.charAt(0).toUpperCase() + freq.slice(1)}`;
-        pdf.text(title, 10, 10);
-        const imgData = chart.toBase64Image();
-        const imgProps = pdf.getImageProperties(imgData);
-        const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
-        const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
-        pdf.addImage(imgData, 'PNG', 10, 20, pdfWidth, pdfHeight);
-        pdf.addPage('portrait');
-        pdf.autoTable({ html: `#${freq}-report-table`, startY: 10 });
-        pdf.save(`${freq}-report.pdf`);
+        exportChartWithTable(
+          chart,
+          `#${freq}-report-table`,
+          title,
+          `${freq}-report.pdf`
+        );
       });
     }
   });

--- a/static/js/report_utils.js
+++ b/static/js/report_utils.js
@@ -1,0 +1,15 @@
+window.exportChartWithTable = function (canvas, tableSelector, title, filename) {
+  const { jsPDF } = window.jspdf;
+  const pdf = new jsPDF({ orientation: 'landscape' });
+  const lines = Array.isArray(title) ? title : [title];
+  lines.forEach((line, idx) => pdf.text(line, 10, 10 + idx * 10));
+  const imgData = canvas.toBase64Image ? canvas.toBase64Image() : canvas.toDataURL('image/png');
+  const imgProps = pdf.getImageProperties(imgData);
+  const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
+  const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+  const imgY = 20 + (lines.length - 1) * 10;
+  pdf.addImage(imgData, 'PNG', 10, imgY, pdfWidth, pdfHeight);
+  pdf.addPage('portrait');
+  pdf.autoTable({ html: tableSelector, startY: 10 });
+  pdf.save(filename);
+};

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -5,6 +5,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
+    <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
     <script src="/static/js/analysis.js" defer></script>
     <script src="{{ url_for('static', filename='js/moat_sql.js') }}" defer></script>

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -11,6 +11,7 @@
   <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
+  <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_sql.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- add exportChartWithTable helper in static/js/report_utils.js
- include report_utils.js in analysis.html and aoi.html
- use helper for FC, NG, and report charts in analysis.js

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e30cd9c788325864507eb107f428e