### PR TITLE
Add reports permission and settings UI

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -36,6 +36,7 @@ function toggleAddUser(){
       <label><input type="checkbox" name="privileges" value="aoi" {% if u['aoi'] %}checked{% endif %}> AOI Report</label>
       <label><input type="checkbox" name="privileges" value="analysis" {% if u['analysis'] %}checked{% endif %}> Data Analysis</label>
       <label><input type="checkbox" name="privileges" value="dashboard" {% if u['dashboard'] %}checked{% endif %}> SPC Dashboard</label>
+      <label><input type="checkbox" name="privileges" value="reports" {% if u['reports'] %}checked{% endif %}> Generate Reports</label>
       <label><input type="checkbox" name="privileges" value="c_suite" {% if u['c_suite'] %}checked{% endif %}> C-suite</label>
       <button type="submit">Save</button>
       <button type="submit" name="action" value="delete">Delete</button>
@@ -50,6 +51,7 @@ function toggleAddUser(){
       <label><input type="checkbox" name="privileges" value="aoi"> AOI Report</label>
       <label><input type="checkbox" name="privileges" value="analysis"> Data Analysis</label>
       <label><input type="checkbox" name="privileges" value="dashboard"> SPC Dashboard</label>
+      <label><input type="checkbox" name="privileges" value="reports"> Generate Reports</label>
       <label><input type="checkbox" name="privileges" value="c_suite"> C-suite</label>
       <button type="submit">Add</button>
     </form>


### PR DESCRIPTION
## Summary
- Support `reports` privilege in database and default users
- Expose `reports` permission in global context and settings management
- Restrict analysis report endpoint to users with report access
- Add "Generate Reports" option in settings page UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f496f72c48325bd01a61b77a408b4