### PR TITLE
Add reports widget to home page

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -52,6 +52,12 @@
       <p>Statistical Controls (<i>in progress</i>)</p>
     </div>
     {% endif %}
+    {% if is_admin or permissions.get('reports') %}
+    <div class="widget" onclick="location.href='/reports'">
+      <h2>Generate Reports</h2>
+      <p>Compile key charts into a single report</p>
+    </div>
+    {% endif %}
     <div class="widget" onclick="location.href='/rework'">
       <h2>Rework</h2>
       <p>Stencil and part lookup tools</p>


### PR DESCRIPTION
## Summary
- add Generate Reports widget with permission check to home page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4bd5b25c83259ce940fafe9daef3