### PR TITLE
Add reports page with access control

### DIFF
--- a/run.py
+++ b/run.py
@@ -1090,6 +1090,14 @@ def analysis_report_data():
         ]
     })
 
+
+@app.route('/reports')
+@login_required
+def reports():
+    if not has_permission('reports'):
+        return redirect('/')
+    return render_template('reports.html')
+
 @app.route('/uploads')
 @login_required
 def list_uploads():

--- a/static/js/generate_reports.js
+++ b/static/js/generate_reports.js
@@ -1,0 +1,5 @@
+// Placeholder for report generation logic
+
+document.getElementById('generate-report')?.addEventListener('click', () => {
+  // TODO: Implement report generation using Chart.js and jsPDF
+});

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Reports{% endblock %}
+{% block head_extra %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="{{ url_for('static', filename='js/generate_reports.js') }}" defer></script>
+{% endblock %}
+{% block content %}
+  <a href="/">← Home</a>
+  <h1>Reports</h1>
+  <label for="start-date">Start Date</label>
+  <input type="date" id="start-date">
+  <label for="end-date">End Date</label>
+  <input type="date" id="end-date">
+  <button id="generate-report">Generate Report</button>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `/reports` route requiring login and reports permission
- Create reports template with date filters and report generation script
- Introduce placeholder `generate_reports.js` for future report generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f50fdefa08325a84190ad3c5e8605