### PR TITLE
Enable PNG export and simplify home layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -30,9 +30,13 @@ a { color: var(--color-accent); }
   padding: 2px 6px;
   cursor: pointer;
 }
-.widgets { display: flex; gap: 20px; margin-top: 20px; }
+.widgets {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin-top: 20px;
+}
 .widget {
-  flex:1;
   border:1px solid var(--color-black);
   border-radius:8px;
   padding:20px;

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -4,6 +4,7 @@
   <!-- Chart.js for control chart rendering -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.png.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
     <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -10,6 +10,7 @@
   <script id="customer-data" type="application/json">{{ customer_rates|tojson }}</script>
   <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.png.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,6 +6,7 @@
     <!-- <h1>HUB</h1> -->
   </div>
   <!-- <button onclick="location.href='{{ url_for('logout') }}'">Logout</button> -->
+  {#
   <div class="job-previews">
     <h2>Floor Jobs Preview</h2>
     <div class="job-grid">
@@ -22,6 +23,7 @@
       {% endfor %}
     </div>
   </div>
+  #}
   <p>Select a section below:</p>
   <div class="widgets">
     <div class="widget" onclick="location.href='/jobs'">

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -3,6 +3,7 @@
 {% block head_extra %}
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.png.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/generate_reports.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load jsPDF PNG plugin so chart exports no longer report an unknown image type
- hide job preview cards on the home page until they’re revisited
- arrange home page widgets in a 4-column grid for easier navigation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5688849883259445c013ecd57384