### PR TITLE
Validate image MIME types before adding to PDFs

### DIFF
--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -376,7 +376,19 @@ window.addEventListener('DOMContentLoaded', () => {
       ['operators','shift','reject','yield'].forEach(name => {
         const chart = reportCharts[`${period}-${name}`];
         if (chart) {
-          const img = chart.toBase64Image();
+          let img = chart.toBase64Image();
+          const validMime = d => typeof d === 'string' && /^data:image\/(png|jpeg);/i.test(d);
+          if (!validMime(img)) {
+            const canvas = chart.canvas;
+            if (canvas && canvas.toDataURL) {
+              img = canvas.toDataURL('image/png');
+            }
+            if (!validMime(img)) {
+              console.error('Unsupported image format for PDF export');
+              alert('Unable to add chart: unsupported image format.');
+              return;
+            }
+          }
           const props = pdf.getImageProperties(img);
           const width = pdf.internal.pageSize.getWidth() - 20;
           const height = (props.height * width) / props.width;

--- a/static/js/generate_reports.js
+++ b/static/js/generate_reports.js
@@ -90,7 +90,16 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
 
   const addChart = (ctx, title) => {
     const canvas = ctx.canvas;
-    const img = canvas.toDataURL('image/png');
+    const validMime = d => typeof d === 'string' && /^data:image\/(png|jpeg);/i.test(d);
+    let img = canvas.toDataURL('image/png');
+    if (!validMime(img)) {
+      img = canvas.toDataURL('image/png');
+      if (!validMime(img)) {
+        console.error('Unsupported image format for PDF export');
+        alert('Unable to add chart: unsupported image format.');
+        return;
+      }
+    }
     const imgProps = pdf.getImageProperties(img);
     const width = pdf.internal.pageSize.getWidth() - 20;
     const height = (imgProps.height * width) / imgProps.width;
@@ -110,4 +119,3 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
 
   pdf.save('report.pdf');
 });
-

--- a/static/js/report_utils.js
+++ b/static/js/report_utils.js
@@ -3,7 +3,16 @@ window.exportChartWithTable = function (canvas, tableSelector, title, filename, 
   const pdf = new jsPDF({ orientation });
   const lines = Array.isArray(title) ? title : [title];
   lines.forEach((line, idx) => pdf.text(line, 10, 10 + idx * 10));
-  const imgData = canvas.toBase64Image ? canvas.toBase64Image() : canvas.toDataURL('image/png');
+  const validMime = data => typeof data === 'string' && /^data:image\/(png|jpeg);/i.test(data);
+  let imgData = canvas.toBase64Image ? canvas.toBase64Image() : canvas.toDataURL('image/png');
+  if (!validMime(imgData)) {
+    imgData = canvas.toDataURL('image/png');
+    if (!validMime(imgData)) {
+      console.error('Unsupported image format for export');
+      alert('Unable to export chart: unsupported image format.');
+      return;
+    }
+  }
   const imgProps = pdf.getImageProperties(imgData);
   const pdfWidth = pdf.internal.pageSize.getWidth() - 20;
   const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;


### PR DESCRIPTION
## Summary
- check image data URLs before pdf.addImage
- convert canvases to PNG when missing MIME type
- notify users if an image remains unsupported

## Testing
- `python3 -m pytest` *(fails: No module named pytest; installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689f58de97f0832595929ee3312b03bc