### PR TITLE
Handle PDF image type fallbacks and include jsPDF JPEG plugin

### DIFF
--- a/static/js/generate_reports.js
+++ b/static/js/generate_reports.js
@@ -90,21 +90,29 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
 
   const addChart = (ctx, title) => {
     const canvas = ctx.canvas;
-    const validMime = d => typeof d === 'string' && /^data:image\/(png|jpeg);/i.test(d);
+    const validMime = d => typeof d === 'string' && /^data:image\/(png|jpe?g);/i.test(d);
     let img = canvas.toDataURL('image/png');
     if (!validMime(img)) {
-      img = canvas.toDataURL('image/png');
+      img = canvas.toDataURL('image/jpeg', 1.0);
       if (!validMime(img)) {
         console.error('Unsupported image format for PDF export');
         alert('Unable to add chart: unsupported image format.');
         return;
       }
     }
-    const imgProps = pdf.getImageProperties(img);
+    let imgProps;
+    try {
+      imgProps = pdf.getImageProperties(img);
+    } catch (err) {
+      console.error(err);
+      alert('Unable to add chart: unsupported image format.');
+      return;
+    }
     const width = pdf.internal.pageSize.getWidth() - 20;
     const height = (imgProps.height * width) / imgProps.width;
+    const type = img.startsWith('data:image/png') ? 'PNG' : 'JPEG';
     pdf.text(title, 10, 10);
-    pdf.addImage(img, 'PNG', 10, 20, width, height);
+    pdf.addImage(img, type, 10, 20, width, height);
   };
 
   addChart(fcCtx, 'False Call Rate');

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -5,6 +5,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.png.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.jpeg.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
     <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -11,6 +11,7 @@
   <script id="yield-data" type="application/json">{{ yield_series|tojson }}</script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.png.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.jpeg.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -4,6 +4,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.png.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.jpeg.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/generate_reports.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Fallback to JPEG export when PNG is unsupported and guard jsPDF image properties
- Allow jpg mime types and catch unsupported chart images
- Load jsPDF JPEG plugin so both PNG and JPEG images are recognized

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f80b293bc832594dacb0400b79092