### PR TITLE
Ensure report canvas dimensions and visibility

### DIFF
--- a/static/js/generate_reports.js
+++ b/static/js/generate_reports.js
@@ -24,8 +24,11 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
 
   const makeCanvas = () => {
     const c = document.createElement('canvas');
+    c.width = 600;
+    c.height = 400;
+    const ctx = c.getContext('2d');
     content.appendChild(c);
-    return c.getContext('2d');
+    return ctx;
   };
 
   const fcCtx = makeCanvas();
@@ -92,6 +95,12 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
   const pdf = new jsPDF();
 
   pdf.html(content, {
-    callback: pdf => pdf.save('report.pdf'),
+    callback: pdf => {
+      pdf.save('report.pdf');
+      container.innerHTML = '';
+      container.style.visibility = 'hidden';
+      container.style.position = 'absolute';
+      container.style.left = '-9999px';
+    },
   });
 });

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -16,5 +16,5 @@
   <label for="end-date">End Date</label>
   <input type="date" id="end-date">
   <button id="generate-report">Generate Report</button>
-  <div id="report-temp" style="display:none"></div>
+  <div id="report-temp" style="visibility:hidden; position:absolute; left:-9999px;"></div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- keep temporary report container off-screen instead of hidden via `display:none`
- set fixed 600×400 canvas dimensions before chart creation
- clear and hide temporary report elements after PDF generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8b2f30ac8325bd2cfdb2a56bd6a5