### PR TITLE
Remove unused home widgets

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -30,12 +30,6 @@
       <h2>Jobs</h2>
       <p>Manage Floor Jobs (<i>in progress</i>)</p>
     </div>
-    {% if is_admin or permissions.get('analysis') %}
-    <div class="widget" onclick="location.href='/analysis'">
-      <h2>Data Analysis</h2>
-      <p>Upload And Data Mine Reports From SPC</p>
-    </div>
-    {% endif %}
     {% if is_admin or permissions.get('part_markings') %}
     <div class="widget" onclick="location.href='/part-markings'">
       <h2>Verified Part Markings</h2>
@@ -44,7 +38,7 @@
     {% endif %}
     {% if is_admin or permissions.get('aoi') %}
     <div class="widget" onclick="location.href='/aoi'">
-      <h2>AOI Daily Report</h2>
+      <h2>AOI</h2>
       <p>View and Upload AOI Reports With Data Insights.</p>
     </div>
     {% endif %}
@@ -52,12 +46,6 @@
     <div class="widget" onclick="location.href='#'">
       <h2>SPC Dashboard</h2>
       <p>Statistical Controls (<i>in progress</i>)</p>
-    </div>
-    {% endif %}
-    {% if is_admin or permissions.get('reports') %}
-    <div class="widget" onclick="location.href='/reports'">
-      <h2>Generate Reports</h2>
-      <p>Compile key charts into a single report</p>
     </div>
     {% endif %}
     <div class="widget" onclick="location.href='/rework'">


### PR DESCRIPTION
## Summary
- Remove Data Analysis and Generate Reports widgets from home page
- Simplify AOI widget title and link to `/aoi`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a34491bc7c83259f8f60d9a745d54a