### PR TITLE
feat: allow sending charts to report

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -1,4 +1,18 @@
 window.addEventListener('DOMContentLoaded', () => {
+  function insertSendButtonAfter(el) {
+    if (!el) return;
+    const next = el.nextElementSibling;
+    if (next && next.classList && next.classList.contains('send-to-report')) return;
+    const section = el.closest('.report-section') || el.closest('.modal') || el.closest('div[id]') || el;
+    const sectionId = section.id || el.id;
+    const btn = document.createElement('button');
+    btn.textContent = 'Send to Report';
+    btn.className = 'send-to-report';
+    btn.addEventListener('click', () => {
+      if (window.addToReport) window.addToReport(sectionId);
+    });
+    el.insertAdjacentElement('afterend', btn);
+  }
   // Divider logic
   const divider = document.getElementById('divider');
   const container = document.getElementById('container');
@@ -300,6 +314,7 @@ window.addEventListener('DOMContentLoaded', () => {
             },
             plugins: [thresholdPlugin]
           });
+          insertSendButtonAfter(ctx);
           const fcTable = document.getElementById('fc-data-table');
           if (fcTable) {
             fcTable.innerHTML = '<thead><tr><th>Model Name</th><th>Avg FalseCall Rate</th><th>Total Boards</th></tr></thead><tbody></tbody>';
@@ -311,6 +326,7 @@ window.addEventListener('DOMContentLoaded', () => {
               else if (row.rate > 10) tr.classList.add('threshold-yellow');
               tbody.appendChild(tr);
             });
+            insertSendButtonAfter(fcTable);
           }
           const entryCount = data.length;
           const totalBoards = data.reduce((sum, r) => sum + r.boards, 0);
@@ -423,6 +439,7 @@ window.addEventListener('DOMContentLoaded', () => {
             },
             plugins: [thresholdPlugin]
           });
+          insertSendButtonAfter(ngCtx);
           const ngTable = document.getElementById('ng-data-table');
           if (ngTable) {
             ngTable.innerHTML = '<thead><tr><th>Model Name</th><th>Avg NG Rate</th><th>Total Boards</th></tr></thead><tbody></tbody>';
@@ -434,6 +451,7 @@ window.addEventListener('DOMContentLoaded', () => {
               else if (row.rate > 0.05) tr.classList.add('threshold-yellow');
               tbody.appendChild(tr);
             });
+            insertSendButtonAfter(ngTable);
           }
           const entryCount = data.length;
           const totalBoards = data.reduce((sum, r) => sum + r.boards, 0);
@@ -521,6 +539,7 @@ window.addEventListener('DOMContentLoaded', () => {
           },
           options: { scales: { y: { beginAtZero: true } } }
         });
+        insertSendButtonAfter(canvas);
         if (table) {
           table.innerHTML = '<thead><tr><th>Period</th><th>Total Boards</th><th>FalseCall PPM</th><th>NG PPM</th></tr></thead><tbody></tbody>';
           const tbody = table.querySelector('tbody');
@@ -535,6 +554,7 @@ window.addEventListener('DOMContentLoaded', () => {
             const avgNg = data.table.reduce((sum, r) => sum + r.ng_ppm, 0) / (data.table.length || 1);
             summaryEl.textContent = `Avg FalseCall PPM: ${avgFc.toFixed(2)}, Avg NG PPM: ${avgNg.toFixed(2)} across ${totalBoards} boards.`;
           }
+          insertSendButtonAfter(table);
         }
       });
     if (pdfBtn) {

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -1,4 +1,18 @@
 window.addEventListener('DOMContentLoaded', () => {
+  function insertSendButtonAfter(el) {
+    if (!el) return;
+    const next = el.nextElementSibling;
+    if (next && next.classList && next.classList.contains('send-to-report')) return;
+    const section = el.closest('.report-section') || el.closest('.modal') || el.closest('div[id]') || el;
+    const sectionId = section.id || el.id;
+    const btn = document.createElement('button');
+    btn.textContent = 'Send to Report';
+    btn.className = 'send-to-report';
+    btn.addEventListener('click', () => {
+      if (window.addToReport) window.addToReport(sectionId);
+    });
+    el.insertAdjacentElement('afterend', btn);
+  }
   // Divider logic
   const divider = document.getElementById('divider');
   const container = document.getElementById('container');
@@ -63,6 +77,7 @@ window.addEventListener('DOMContentLoaded', () => {
           }
         }
       });
+      insertSendButtonAfter(ctx);
     }
   }
 
@@ -86,6 +101,7 @@ window.addEventListener('DOMContentLoaded', () => {
         data: { labels: dates, datasets },
         options: { scales: { y: { beginAtZero: true } } }
       });
+      insertSendButtonAfter(ctx);
     }
   }
 
@@ -105,6 +121,7 @@ window.addEventListener('DOMContentLoaded', () => {
         },
         options: { scales: { y: { beginAtZero: true } } }
       });
+      insertSendButtonAfter(ctx);
     }
   }
 
@@ -135,6 +152,7 @@ window.addEventListener('DOMContentLoaded', () => {
           }
         }
       });
+      insertSendButtonAfter(ctx);
     }
   }
 
@@ -144,6 +162,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const table = document.querySelector('#aoi-table table');
   if (table) {
+    insertSendButtonAfter(table);
     table.addEventListener('click', async e => {
       if (!e.target.classList.contains('delete-row')) return;
       const row = e.target.closest('tr');
@@ -184,8 +203,11 @@ window.addEventListener('DOMContentLoaded', () => {
     if (modalChart) modalChart.destroy();
     modalTitle.textContent = title;
     modalChart = new Chart(modalCanvas, config);
+    insertSendButtonAfter(modalCanvas);
     modalHead.innerHTML = '<tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr>';
     modalBody.innerHTML = rows.map(r => '<tr>' + r.map(c => `<td>${c}</td>`).join('') + '</tr>').join('');
+    const modalTable = document.getElementById('modal-table');
+    if (modalTable) insertSendButtonAfter(modalTable);
     chartModal.style.display = 'block';
   }
 
@@ -298,6 +320,7 @@ window.addEventListener('DOMContentLoaded', () => {
           },
           options: { scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } } }
         });
+        insertSendButtonAfter(ctx);
       }
     }
 
@@ -313,6 +336,7 @@ window.addEventListener('DOMContentLoaded', () => {
           },
           options: { scales: { y: { beginAtZero: true } } }
         });
+        insertSendButtonAfter(ctx);
       }
     }
 
@@ -328,6 +352,7 @@ window.addEventListener('DOMContentLoaded', () => {
           },
           options: { scales: { y: { beginAtZero: true } } }
         });
+        insertSendButtonAfter(ctx);
       }
     }
 
@@ -351,19 +376,21 @@ window.addEventListener('DOMContentLoaded', () => {
             }
           }
         });
+        insertSendButtonAfter(ctx);
       }
     }
-
-    const table = document.querySelector(`#${freq}-table tbody`);
-    if (table) {
-      table.innerHTML = '';
+    const tableEl = document.getElementById(`${freq}-table`);
+    const tbody = tableEl ? tableEl.querySelector('tbody') : null;
+    if (tbody) {
+      tbody.innerHTML = '';
       (data.assemblies || []).forEach(r => {
         const tr = document.createElement('tr');
         const yieldPct = r.yield ? (r.yield * 100).toFixed(2) + '%' : '0%';
         tr.innerHTML = `<td>${r.assembly}</td><td>${r.inspected}</td><td>${r.rejected}</td><td>${yieldPct}</td>`;
-        table.appendChild(tr);
+        tbody.appendChild(tr);
       });
     }
+    if (tableEl) insertSendButtonAfter(tableEl);
   }
 
   document.querySelectorAll('.download-report').forEach(btn => {

--- a/static/js/report_collector.js
+++ b/static/js/report_collector.js
@@ -1,0 +1,35 @@
+(function(){
+  function addToReport(sectionId) {
+    const section = document.getElementById(sectionId);
+    const previewContainer = document.getElementById('report-preview');
+    if (!section || !previewContainer) return;
+
+    const preview = document.createElement('div');
+    preview.className = 'report-preview-item';
+
+    const canvas = section.querySelector('canvas');
+    if (canvas && canvas.toDataURL) {
+      try {
+        const img = document.createElement('img');
+        img.src = canvas.toDataURL('image/png');
+        preview.appendChild(img);
+      } catch (err) {
+        console.error('Canvas capture failed', err);
+      }
+    }
+
+    const table = section.querySelector('table');
+    if (table) {
+      preview.appendChild(table.cloneNode(true));
+    }
+
+    const summary = section.querySelector('.chart-summary');
+    if (summary) {
+      preview.appendChild(summary.cloneNode(true));
+    }
+
+    previewContainer.appendChild(preview);
+  }
+
+  window.addToReport = addToReport;
+})();

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -11,6 +11,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.jpeg.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/report_collector.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
 {% endblock %}
 {% block content %}

--- a/templates/reports_section.html
+++ b/templates/reports_section.html
@@ -4,4 +4,5 @@
 <label for="end-date">End Date</label>
 <input type="date" id="end-date">
 <button id="generate-report">Generate Report</button>
+<div id="report-preview"></div>
 <div id="report-temp" style="visibility:hidden; position:absolute; left:-9999px;"></div>


### PR DESCRIPTION
## Summary
- add report preview area and collector script
- wire up "Send to Report" buttons for AOI dashboard and analysis charts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3475e875c83259ccbdba1b8184934