### PR TITLE
Add saved report persistence and retrieval UI

### DIFF
--- a/templates/reports_section.html
+++ b/templates/reports_section.html
@@ -4,5 +4,8 @@
 <label for="end-date">End Date</label>
 <input type="date" id="end-date">
 <button id="generate-report">Generate Report</button>
+<button id="save-report">Save Report</button>
+<label for="saved-report-select">Saved Reports</label>
+<select id="saved-report-select"></select>
 <div id="report-preview"></div>
 <div id="report-temp" style="visibility:hidden; position:absolute; left:-9999px;"></div>

--- a/tests/test_saved_reports.py
+++ b/tests/test_saved_reports.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from run import app, init_db, get_db
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, reports) VALUES (?,?,1)",
+        ('reporter', 'pw'),
+    )
+    conn.commit()
+    conn.close()
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user'] = 'reporter'
+        yield client
+
+
+def test_save_and_load_report(client):
+    resp = client.post('/reports/save', json={'name': 'Sample', 'content': '[]'})
+    assert resp.status_code == 200
+    report_id = resp.get_json()['id']
+
+    list_resp = client.get('/reports/list')
+    assert list_resp.status_code == 200
+    reports = list_resp.get_json()
+    assert any(r['id'] == report_id for r in reports)
+
+    fetch_resp = client.get(f'/reports/{report_id}')
+    assert fetch_resp.status_code == 200
+    data = fetch_resp.get_json()
+    assert data['content'] == '[]'


### PR DESCRIPTION
## Summary
- store saved reports in new `saved_reports` table
- expose `/reports/save`, `/reports/list`, and `/reports/<id>` endpoints
- enhance Report Generation tab with save dialog and saved report dropdown
- add tests for saving and loading reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a356e46bd08325918a1a0783c1d21f