### PR TITLE
Add draggable report generation overlay window

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -388,3 +388,61 @@ body.dark-mode .job-preview.danger { background: #a72828; border-color: #660000;
 .saved-query-bar {
   margin-bottom: 8px;
 }
+
+/* Report generation window */
+.report-window {
+  position: fixed;
+  top: 10%;
+  left: 10%;
+  width: 80%;
+  height: 80%;
+  background: var(--color-white);
+  border: 1px solid var(--color-black);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  display: flex;
+  flex-direction: column;
+  z-index: 1001;
+}
+
+.report-window-header {
+  background: var(--color-accent);
+  color: var(--color-white);
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: move;
+}
+
+.report-window-header input[type="text"] {
+  flex: 1;
+}
+
+.report-window-header button {
+  background: var(--color-white);
+  color: var(--color-black);
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.report-window-body {
+  flex: 1;
+  overflow: auto;
+  padding: 8px;
+}
+
+.report-item {
+  margin-bottom: 20px;
+}
+
+.report-item img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.report-item p {
+  margin: 0 0 8px;
+  text-align: center;
+}

--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -1,0 +1,114 @@
+(function() {
+  function makeCanvasDraggable(canvas) {
+    if (canvas.dataset.draggableReady) return;
+    canvas.dataset.draggableReady = 'true';
+    canvas.setAttribute('draggable', 'true');
+    canvas.addEventListener('dragstart', e => {
+      try {
+        const dataUrl = canvas.toDataURL('image/png');
+        e.dataTransfer.setData('text/plain', dataUrl);
+      } catch (err) {
+        console.error('Failed to export canvas', err);
+      }
+    });
+  }
+
+  function initDraggables(root = document) {
+    root.querySelectorAll && root.querySelectorAll('canvas').forEach(makeCanvasDraggable);
+  }
+
+  const observer = new MutationObserver(mutations => {
+    mutations.forEach(m => {
+      m.addedNodes.forEach(node => {
+        if (node.nodeType !== 1) return;
+        if (node.tagName === 'CANVAS') {
+          makeCanvasDraggable(node);
+        } else {
+          initDraggables(node);
+        }
+      });
+    });
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initDraggables();
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+
+  window.openReportWindow = function() {
+    if (document.getElementById('report-window')) return;
+
+    const win = document.createElement('div');
+    win.id = 'report-window';
+    win.className = 'report-window';
+
+    const header = document.createElement('div');
+    header.className = 'report-window-header';
+    header.innerHTML = '<input type="text" id="report-caption" placeholder="Chart caption"><button id="report-print">Print</button><button id="report-close" title="Close">\u00d7</button>';
+
+    const body = document.createElement('div');
+    body.className = 'report-window-body';
+
+    win.appendChild(header);
+    win.appendChild(body);
+    document.body.appendChild(win);
+
+    // dragging
+    let offsetX = 0, offsetY = 0, dragging = false;
+    header.addEventListener('mousedown', e => {
+      if (e.target.tagName === 'INPUT') return;
+      dragging = true;
+      offsetX = e.clientX - win.offsetLeft;
+      offsetY = e.clientY - win.offsetTop;
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', up);
+    });
+    function move(e) {
+      if (!dragging) return;
+      win.style.left = (e.clientX - offsetX) + 'px';
+      win.style.top = (e.clientY - offsetY) + 'px';
+    }
+    function up() {
+      if (!dragging) return;
+      dragging = false;
+      document.removeEventListener('mousemove', move);
+      document.removeEventListener('mouseup', up);
+    }
+
+    header.querySelector('#report-close').addEventListener('click', () => {
+      win.remove();
+    });
+
+    body.addEventListener('dragover', e => e.preventDefault());
+    body.addEventListener('drop', e => {
+      e.preventDefault();
+      const dataUrl = e.dataTransfer.getData('text/plain');
+      if (!dataUrl) return;
+      const wrapper = document.createElement('div');
+      wrapper.className = 'report-item';
+      const caption = document.getElementById('report-caption').value;
+      const p = document.createElement('p');
+      p.textContent = caption;
+      p.contentEditable = 'true';
+      const img = document.createElement('img');
+      img.src = dataUrl;
+      wrapper.appendChild(p);
+      wrapper.appendChild(img);
+      body.appendChild(wrapper);
+      document.getElementById('report-caption').value = '';
+    });
+
+    header.querySelector('#report-print').addEventListener('click', () => {
+      if (!window.jspdf || !window.html2canvas) return;
+      const { jsPDF } = window.jspdf;
+      html2canvas(body).then(canvas => {
+        const imgData = canvas.toDataURL('image/png');
+        const pdf = new jsPDF('p', 'pt', 'a4');
+        const pdfWidth = pdf.internal.pageSize.getWidth();
+        const pdfHeight = canvas.height * pdfWidth / canvas.width;
+        pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+        pdf.save('report.pdf');
+      });
+    });
+  };
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,9 @@
   <script src="/static/js/theme.js" defer></script>
   <script src="/static/js/editable.js" defer></script>
   <script src="/static/js/sql_popup.js" defer></script>
+  <script src="/static/js/html2canvas.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="/static/js/report_window.js" defer></script>
   {% block head_extra %}{% endblock %}
 </head>
 <body data-admin="{{ 'true' if is_admin else 'false' }}">

--- a/templates/home.html
+++ b/templates/home.html
@@ -55,7 +55,7 @@
     </div>
     {% endif %}
     {% if is_admin or permissions.get('reports') %}
-    <div class="widget" onclick="location.href='/reports'">
+    <div class="widget" onclick="openReportWindow()">
       <h2>Generate Reports</h2>
       <p>Compile key charts into a single report</p>
     </div>


### PR DESCRIPTION
## Summary
- Open Generate Reports tab into draggable overlay with caption input and print option
- Load required libraries globally and make charts draggable for drop-in report assembly
- Style report window overlay to match application theme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a35ffbcd608325830908311e8d72b2