### PR TITLE
feat: persistent floating report generator

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -199,6 +199,85 @@ table thead th {
   color: var(--color-black);
 }
 
+/* Floating report button */
+#report-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-accent);
+  color: var(--color-white);
+  font-size: 28px;
+  cursor: pointer;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+}
+
+/* Report window styles */
+.report-window {
+  position: fixed;
+  bottom: 100px;
+  right: 20px;
+  z-index: 1000;
+  background: var(--color-white);
+  border: 1px solid var(--color-black);
+  box-shadow: 0 2px 10px rgba(0,0,0,0.5);
+}
+
+.report-window-header {
+  background: var(--color-accent);
+  color: var(--color-white);
+  padding: 5px 10px;
+  display: flex;
+  align-items: center;
+  cursor: move;
+}
+
+.report-window-header .right {
+  margin-left: auto;
+}
+
+.report-window-header button {
+  background: transparent;
+  border: none;
+  color: var(--color-white);
+  margin-left: 5px;
+  cursor: pointer;
+}
+
+.report-window-body {
+  padding: 10px;
+  overflow: auto;
+  max-height: 70vh;
+}
+
+.report-page {
+  width: 794px;
+  min-height: 1123px;
+  margin: 0 auto 20px;
+  border: 1px solid var(--color-black);
+  background: var(--color-white);
+  box-sizing: border-box;
+  page-break-after: always;
+}
+
+.report-page:last-child {
+  page-break-after: auto;
+}
+
+.report-item img {
+  width: 100%;
+  height: auto;
+}
+
+.report-text {
+  width: 100%;
+  display: block;
+}
+
 .action-card label {
   display: block;
   margin-top: 10px;
@@ -381,68 +460,11 @@ body.dark-mode .job-preview.danger { background: #a72828; border-color: #660000;
   text-align: center;
 }
 
+
 .sql-popup.collapsed .sql-popup-body {
   display: none;
 }
 
 .saved-query-bar {
   margin-bottom: 8px;
-}
-
-/* Report generation window */
-.report-window {
-  position: fixed;
-  top: 10%;
-  left: 10%;
-  width: 80%;
-  height: 80%;
-  background: var(--color-white);
-  border: 1px solid var(--color-black);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-  display: flex;
-  flex-direction: column;
-  z-index: 1001;
-}
-
-.report-window-header {
-  background: var(--color-accent);
-  color: var(--color-white);
-  padding: 4px 8px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: move;
-}
-
-.report-window-header input[type="text"] {
-  flex: 1;
-}
-
-.report-window-header button {
-  background: var(--color-white);
-  color: var(--color-black);
-  border: none;
-  padding: 4px 8px;
-  cursor: pointer;
-}
-
-.report-window-body {
-  flex: 1;
-  overflow: auto;
-  padding: 8px;
-}
-
-.report-item {
-  margin-bottom: 20px;
-}
-
-.report-item img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
-.report-item p {
-  margin: 0 0 8px;
-  text-align: center;
 }

--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -1,5 +1,4 @@
 window.addEventListener('DOMContentLoaded', () => {
-  if (typeof openReportWindow === 'function') openReportWindow();
   // Divider logic
   const divider = document.getElementById('divider');
   const container = document.getElementById('container');

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -1,5 +1,4 @@
 window.addEventListener('DOMContentLoaded', () => {
-  if (typeof openReportWindow === 'function') openReportWindow();
   // Divider logic
   const divider = document.getElementById('divider');
   const container = document.getElementById('container');

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,16 @@
       </ul>
     {% endif %}
   {% endwith %}
+  {% if is_admin or permissions.get('reports') %}
+  <button id="report-button" title="Generate Report" onclick="openReportWindow()">\u270e</button>
+  {% endif %}
   {% block content %}{% endblock %}
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      if (localStorage.getItem('report-window-open') === 'true' && typeof openReportWindow === 'function') {
+        openReportWindow();
+      }
+    });
+  </script>
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -54,12 +54,6 @@
       <p>Statistical Controls (<i>in progress</i>)</p>
     </div>
     {% endif %}
-    {% if is_admin or permissions.get('reports') %}
-    <div class="widget" onclick="openReportWindow()">
-      <h2>Generate Reports</h2>
-      <p>Compile key charts into a single report</p>
-    </div>
-    {% endif %}
     <div class="widget" onclick="location.href='/rework'">
       <h2>Rework</h2>
       <p>Stencil and part lookup tools</p>


### PR DESCRIPTION
## Summary
- add floating "Generate Report" button available on every page
- persist report window and contents across navigation and organize as printable A4 pages
- simplify analysis and AOI scripts to respect report window state

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36642e5c883258294a971586a9c5e