### PR TITLE
Require SECRET_KEY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 SPCApp is a small web application for process control.
 
+## Deployment
+
+The application requires a secret key for session management. Set the
+`SECRET_KEY` environment variable before starting the server; it is
+mandatory and the app will fail to start if it is missing.
+
 ## SAP Integration
 
 The application can optionally retrieve material data from SAP. This

--- a/run.py
+++ b/run.py
@@ -40,7 +40,10 @@ def parse_aoi_rows(path: str):
 
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = 'uploads'
-app.secret_key = os.environ.get('SECRET_KEY', 'spc_secret')
+secret_key = os.environ.get('SECRET_KEY')
+if not secret_key:
+    raise RuntimeError("SECRET_KEY environment variable is required")
+app.secret_key = secret_key
 DATABASE = 'spcapp.db'
 USE_SAP = os.environ.get('USE_SAP', 'false').lower() == 'true'
 sap_service = create_sap_service(use_real=USE_SAP)

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -13,6 +13,7 @@
         <li><a href="#analysis">Analysis</a></li>
         <li><a href="#settings">Settings</a></li>
         <li><a href="#admin-users">Adding Users</a></li>
+        <li><a href="#deployment">Deployment</a></li>
         <li><a href="#sap">SAP Integration</a></li>
       </ul>
     </div>
@@ -80,6 +81,15 @@
         <li>Enter a username and password.</li>
         <li>Check the desired feature privileges.</li>
         <li>Submit the form to add the new user.</li>
+      </ol>
+      <a href="#top">Back to top</a>
+    </div>
+    <div class="action-card">
+      <h2 id="deployment">Deployment</h2>
+      <p>Configure environment variables before running the server.</p>
+      <ol>
+        <li><code>SECRET_KEY</code> must be set; the app will not start without it.</li>
+        <li>Optional: set <code>USE_SAP</code> to <code>true</code> to enable real SAP calls.</li>
       </ol>
       <a href="#top">Back to top</a>
     </div>


### PR DESCRIPTION
## Summary
- remove fallback secret and read SECRET_KEY from environment only
- document required SECRET_KEY variable in README and docs

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36e27904083258fd122f6db015c31