### PR TITLE
Improve report PDF chart sizing and add heading options

### DIFF
--- a/static/js/generate_reports.js
+++ b/static/js/generate_reports.js
@@ -19,13 +19,22 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
   const container = document.getElementById('report-temp');
   container.innerHTML = '';
 
+  const { jsPDF } = window.jspdf;
+  const pdf = new jsPDF();
+  const pageWidth = pdf.internal.pageSize.getWidth();
+  const pageWidthPx = (pageWidth / 25.4) * 96; // convert mm to px
+
   const content = document.createElement('div');
+  content.style.width = pageWidthPx + 'px';
   container.appendChild(content);
 
   const makeCanvas = () => {
     const c = document.createElement('canvas');
-    c.width = 600;
-    c.height = 400;
+    const h = pageWidthPx * (2 / 3);
+    c.style.width = pageWidthPx + 'px';
+    c.style.height = h + 'px';
+    c.width = pageWidthPx * 2;
+    c.height = h * 2;
     const ctx = c.getContext('2d');
     content.appendChild(c);
     return ctx;
@@ -90,9 +99,6 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
     }),
   ];
 
-  const { jsPDF } = window.jspdf;
-  const pdf = new jsPDF();
-
   await Promise.all(
     charts.map(chart =>
       new Promise(res => {
@@ -103,6 +109,7 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
   );
 
   pdf.html(content, {
+    html2canvas: { scale: 1 },
     callback: pdf => {
       pdf.save('report.pdf');
       container.innerHTML = '';

--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -57,7 +57,7 @@
 
     const header = document.createElement('div');
     header.className = 'report-window-header';
-    header.innerHTML = '<button id="report-add-text">Add Text</button><div class="right"><button id="report-print">Print</button><button id="report-close" title="Close">\u00d7</button></div>';
+    header.innerHTML = '<button id="report-add-text">Add Text</button><button id="report-add-h1">Add Header 1</button><button id="report-add-h2">Add Header 2</button><div class="right"><button id="report-print">Print</button><button id="report-close" title="Close">\u00d7</button></div>';
 
     const body = document.createElement('div');
     body.className = 'report-window-body';
@@ -121,21 +121,25 @@
       localStorage.removeItem('report-content');
     });
 
-    header.querySelector('#report-add-text').addEventListener('click', () => {
-      const p = document.createElement('p');
-      p.className = 'report-text';
-      p.contentEditable = 'true';
-      addToPage(p);
-      p.focus();
-      p.addEventListener('keydown', e => {
+    function addEditable(tag) {
+      const el = document.createElement(tag);
+      el.className = 'report-text';
+      el.contentEditable = 'true';
+      addToPage(el);
+      el.focus();
+      el.addEventListener('keydown', e => {
         if (e.key === 'Enter') {
           e.preventDefault();
-          p.contentEditable = 'false';
-          p.blur();
+          el.contentEditable = 'false';
+          el.blur();
           save();
         }
       });
-    });
+    }
+
+    header.querySelector('#report-add-text').addEventListener('click', () => addEditable('p'));
+    header.querySelector('#report-add-h1').addEventListener('click', () => addEditable('h1'));
+    header.querySelector('#report-add-h2').addEventListener('click', () => addEditable('h2'));
 
     body.addEventListener('dragover', e => e.preventDefault());
     body.addEventListener('drop', e => {


### PR DESCRIPTION
## Summary
- Scale report charts to the PDF page width using jsPDF measurements to avoid blurriness.
- Allow report builder to insert Header 1 and Header 2 elements alongside existing text blocks.

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3749735f88325be3595f2a799e717