### PR TITLE
Allow margin selection and landscape PDF for report window

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -255,8 +255,8 @@ table thead th {
 }
 
 .report-page {
-  width: 794px;
-  min-height: 1123px;
+  width: 1123px;
+  min-height: 794px;
   margin: 0 auto 20px;
   border: 1px solid var(--color-black);
   background: var(--color-white);
@@ -271,6 +271,8 @@ table thead th {
 .report-item img {
   width: 100%;
   height: auto;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 .report-text {


### PR DESCRIPTION
## Summary
- Let users choose PDF margins in report popup
- Export report PDFs in landscape layout and scale pages with margins
- Ensure dragged images fit within report pages

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab61c81c8325902f773c09a55a44