### PR TITLE
Make report items resizable and persist their dimensions

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -269,10 +269,16 @@ table thead th {
   page-break-after: auto;
 }
 
+.report-item {
+  resize: both;
+  overflow: hidden;
+  max-width: 100%;
+  max-height: 100%;
+}
+
 .report-item img {
   width: 100%;
-  height: auto;
-  max-height: 100%;
+  height: 100%;
   object-fit: contain;
 }
 

--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -97,6 +97,16 @@
       localStorage.setItem('report-content', body.innerHTML);
     }
 
+    function makeReportItemResizable(wrapper) {
+      wrapper.addEventListener('mouseup', () => {
+        wrapper.style.width = wrapper.offsetWidth + 'px';
+        wrapper.style.height = wrapper.offsetHeight + 'px';
+        save();
+      });
+    }
+
+    body.querySelectorAll('.report-item').forEach(makeReportItemResizable);
+
     // dragging
     let offsetX = 0, offsetY = 0, dragging = false;
     header.addEventListener('mousedown', e => {
@@ -187,7 +197,14 @@
       wrapper.className = 'report-item';
       const img = document.createElement('img');
       img.src = dataUrl;
+      img.addEventListener('load', () => {
+        wrapper.style.width = img.naturalWidth + 'px';
+        wrapper.style.height = img.naturalHeight + 'px';
+        wrapper.style.aspectRatio = img.naturalWidth + '/' + img.naturalHeight;
+        save();
+      });
       wrapper.appendChild(img);
+      makeReportItemResizable(wrapper);
       addToPage(wrapper);
     });
 


### PR DESCRIPTION
## Summary
- Allow report items to be resized via CSS and ensure images fill their container
- Save report item dimensions on resize and restore aspect ratio

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5fa3ba5cc83259261423decc99d83