### PR TITLE
Handle both paddings when paging report items

### DIFF
--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -134,8 +134,10 @@
       let page = body.lastElementChild;
       page.appendChild(node);
       const style = getComputedStyle(page);
-      const limit = page.clientHeight - parseFloat(style.paddingBottom || 0);
-      if (node.offsetTop + node.offsetHeight > limit) {
+      const padTop = parseFloat(style.paddingTop || 0);
+      const padBottom = parseFloat(style.paddingBottom || 0);
+      const usable = page.clientHeight - padTop - padBottom;
+      if (node.offsetTop + node.offsetHeight - padTop > usable) {
         page.removeChild(node);
         page = createPage();
         body.appendChild(page);


### PR DESCRIPTION
## Summary
- account for top and bottom page padding when deciding if a report item fits on the current page

## Testing
- `PYTHONDONTWRITEBYTECODE=1 SECRET_KEY=testing pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60ebeefcc83259ea779851bfc0760