### PR TITLE
Scale dropped images to page width

### DIFF
--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -200,9 +200,19 @@
       const img = document.createElement('img');
       img.src = dataUrl;
       img.addEventListener('load', () => {
-        wrapper.style.width = img.naturalWidth + 'px';
-        wrapper.style.height = img.naturalHeight + 'px';
+        const page = wrapper.closest('.report-page');
+        const style = getComputedStyle(page);
+        const availableWidth = page.clientWidth -
+          parseFloat(style.paddingLeft || 0) -
+          parseFloat(style.paddingRight || 0);
+        const scale = Math.min(1, availableWidth / img.naturalWidth);
+        const scaledWidth = img.naturalWidth * scale;
+        const scaledHeight = img.naturalHeight * scale;
+        wrapper.style.width = scaledWidth + 'px';
+        wrapper.style.height = scaledHeight + 'px';
         wrapper.style.aspectRatio = img.naturalWidth + '/' + img.naturalHeight;
+        img.style.width = '100%';
+        img.style.height = 'auto';
         save();
       });
       wrapper.appendChild(img);


### PR DESCRIPTION
## Summary
- Scale images dropped into the report window to fit within the page width
- Preserve aspect ratio by sizing image to wrapper and adjusting styles

## Testing
- `SECRET_KEY=test python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60f90d20c8325974014fa3f43cef4