### PR TITLE
Wrap report text items for resizing

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -283,8 +283,8 @@ table thead th {
 }
 
 .report-text {
-  width: 100%;
-  display: block;
+  display: inline-block;
+  width: auto;
 }
 
 .action-card label {

--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -174,10 +174,13 @@
     });
 
     function addEditable(tag) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'report-item report-text';
       const el = document.createElement(tag);
-      el.className = 'report-text';
       el.contentEditable = 'true';
-      addToPage(el);
+      wrapper.appendChild(el);
+      makeReportItemResizable(wrapper);
+      addToPage(wrapper);
       el.focus();
       el.addEventListener('keydown', e => {
         if (e.key === 'Enter') {


### PR DESCRIPTION
## Summary
- Wrap editable report text inside a `.report-item report-text` container
- Make text containers resizable and allow inline positioning
- Adjust `.report-text` styling for inline-block width auto

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a614b316c8832584d954bfad2d0a25