### PR TITLE
Improve report item printing layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -270,10 +270,17 @@ table thead th {
 }
 
 .report-item {
+  display: inline-block;
+  vertical-align: top;
+  border: 1px solid #ccc;
   resize: both;
   overflow: hidden;
   max-width: 100%;
   max-height: 100%;
+}
+
+.no-border {
+  border: none;
 }
 
 .report-item img {

--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -268,6 +268,8 @@
 
     header.querySelector('#report-print').addEventListener('click', async () => {
       if (!window.jspdf || !window.html2canvas) return;
+      const reportItems = body.querySelectorAll('.report-item');
+      reportItems.forEach(item => item.classList.add('no-border'));
       const { jsPDF } = window.jspdf;
       const pxToPt = 72 / 96; // convert CSS pixels to PDF points
       const pdf = new jsPDF('l', 'pt', 'a4');
@@ -287,6 +289,7 @@
         if (i < pages.length - 1) pdf.addPage('l');
       }
       pdf.save('report.pdf');
+      reportItems.forEach(item => item.classList.remove('no-border'));
     });
 
     window.addEventListener('beforeunload', save);


### PR DESCRIPTION
## Summary
- Style `.report-item` with inline-block display, top alignment, and a light grey border
- Provide `.no-border` helper class to remove borders
- Temporarily toggle borders off during PDF generation to keep printed report clean

## Testing
- `SECRET_KEY=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61d34c1b88325a4440223cff239a0