### PR TITLE
Use portrait orientation for report pages

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -255,8 +255,8 @@ table thead th {
 }
 
 .report-page {
-  width: 1123px;
-  height: 794px;
+  width: 794px;
+  height: 1123px;
   margin: 0 auto 20px;
   border: 1px solid var(--color-black);
   background: var(--color-white);

--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -272,7 +272,7 @@
       reportItems.forEach(item => item.classList.add('no-border'));
       const { jsPDF } = window.jspdf;
       const pxToPt = 72 / 96; // convert CSS pixels to PDF points
-      const pdf = new jsPDF('l', 'pt', 'a4');
+      const pdf = new jsPDF('p', 'pt', 'a4');
       const pages = body.querySelectorAll('.report-page');
       const pageWidth = pdf.internal.pageSize.getWidth();
       const pageHeight = pdf.internal.pageSize.getHeight();
@@ -286,7 +286,7 @@
         const imgWidth = canvas.width * pxToPt * ratio;
         const imgHeight = canvas.height * pxToPt * ratio;
         pdf.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
-        if (i < pages.length - 1) pdf.addPage('l');
+        if (i < pages.length - 1) pdf.addPage('p');
       }
       pdf.save('report.pdf');
       reportItems.forEach(item => item.classList.remove('no-border'));


### PR DESCRIPTION
## Summary
- adjust report page CSS to A4 portrait dimensions
- generate report PDFs in portrait orientation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61e0c79588325bbf11e570c488c12