### PR TITLE
Add Rev and JobNumber fields and MOAT stddev chart

### DIFF
--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -184,6 +184,73 @@
               </div>
             </div>
             <div class="action-card">
+              <h2>Std Dev - Avg FC per Assembly</h2>
+              <p class="desc">Analyze false call rate distribution per assembly.</p>
+              <button id="stddev-chart-btn" title="Show or hide chart options">Chart Settings</button>
+              <div id="stddev-chart-settings" style="display:none; margin-top:10px;">
+                <label>Start Date
+                  <input type="date" id="std-start-date" title="Start date for data range">
+                </label><br>
+                <label>End Date
+                  <input type="date" id="std-end-date" title="End date for data range">
+                </label><br>
+                <label>Y Max
+                  <input type="number" id="std-y-max" value="50" step="0.1" title="Maximum value for Y-axis">
+                </label><br>
+                <label>Min Boards
+                  <input type="number" id="std-min-boards" value="7" title="Minimum boards required">
+                </label><br>
+                <label>Model Name
+                  <input list="model-list" id="std-model-name-1" placeholder="Start typing..." title="Select model name">
+                  <span id="std-model-name-and-2" style="display:none">and</span>
+                  <input list="model-list" id="std-model-name-2" style="display:none" placeholder="Start typing..." title="Select model name">
+                  <span id="std-model-name-and-3" style="display:none">and</span>
+                  <input list="model-list" id="std-model-name-3" style="display:none" placeholder="Start typing..." title="Select model name">
+                  <span id="std-model-name-and-4" style="display:none">and</span>
+                  <input list="model-list" id="std-model-name-4" style="display:none" placeholder="Start typing..." title="Select model name">
+                </label><br>
+                <label>Lines
+                  <select id="std-line-select-1">
+                    <option value="all">All Lines</option>
+                    <option value="offline">Line Offline</option>
+                    <option value="0">Line 0</option>
+                    <option value="1">Line 1</option>
+                    <option value="2">Line 2</option>
+                    <option value="3">Line 3</option>
+                  </select>
+                  <span id="std-line-and-2" style="display:none">and</span>
+                  <select id="std-line-select-2" style="display:none">
+                    <option value="">-- Select --</option>
+                    <option value="offline">Line Offline</option>
+                    <option value="0">Line 0</option>
+                    <option value="1">Line 1</option>
+                    <option value="2">Line 2</option>
+                    <option value="3">Line 3</option>
+                  </select>
+                  <span id="std-line-and-3" style="display:none">and</span>
+                  <select id="std-line-select-3" style="display:none">
+                    <option value="">-- Select --</option>
+                    <option value="offline">Line Offline</option>
+                    <option value="0">Line 0</option>
+                    <option value="1">Line 1</option>
+                    <option value="2">Line 2</option>
+                    <option value="3">Line 3</option>
+                  </select>
+                  <span id="std-line-and-4" style="display:none">and</span>
+                  <select id="std-line-select-4" style="display:none">
+                    <option value="">-- Select --</option>
+                    <option value="offline">Line Offline</option>
+                    <option value="0">Line 0</option>
+                    <option value="1">Line 1</option>
+                    <option value="2">Line 2</option>
+                    <option value="3">Line 3</option>
+                  </select>
+                </label><br>
+                <p class="field-desc">Generate the chart using the selected parameters.</p>
+                <button id="run-std-chart-btn" title="Generate standard deviation chart">Run Chart</button>
+              </div>
+            </div>
+            <div class="action-card">
               <h2>Run SQL Query</h2>
             <form id="sql-form">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -374,6 +441,14 @@
           </select>
         </label>
         <button id="download-ng-pdf">Download PDF</button>
+      </div>
+    </div>
+    <div id="chart-stddev-modal" class="modal">
+      <div class="modal-content">
+        <span id="close-chart-stddev-modal" class="close">&times;</span>
+        <h2>Std Dev - Avg FC per Assembly</h2>
+        <canvas id="chart-stddev-canvas" height="200"></canvas>
+        <p id="stddev-chart-summary" class="chart-summary"></p>
       </div>
     </div>
   {% endif %}

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -55,6 +55,12 @@
               <label>Assembly
                 <input type="text" name="assembly">
               </label><br>
+              <label>Rev
+                <input type="text" name="rev">
+              </label><br>
+              <label>Job Number
+                <input type="text" name="job_number">
+              </label><br>
               <label>Quantity Inspected
                 <input type="number" name="qty_inspected" min="0">
               </label><br>
@@ -257,6 +263,8 @@
             <th>Operator</th>
             <th>Customer</th>
             <th>Assembly</th>
+            <th>Rev</th>
+            <th>Job Number</th>
             <th>Quantity Inspected</th>
             <th>Quantity Rejected</th>
             <th>Additional Information</th>
@@ -273,6 +281,8 @@
             <td>{{ r['operator'] }}</td>
             <td>{{ r['customer'] }}</td>
             <td>{{ r['assembly'] }}</td>
+            <td>{{ r['rev'] }}</td>
+            <td>{{ r['job_number'] }}</td>
             <td>{{ r['qty_inspected'] }}</td>
             <td>{{ r['qty_rejected'] }}</td>
             <td>{{ r['additional_info'] }}</td>

--- a/tests/test_aoi_report.py
+++ b/tests/test_aoi_report.py
@@ -9,14 +9,15 @@ from run import parse_aoi_rows, app, init_db, get_db
 
 def test_parse_aoi_rows(tmp_path):
     data = [
-        ['Alice', 'Cust1', 'Asm1', 10, 1, 'note1'],
-        ['Bob', 'Cust2', 'Asm2', 20, 2, 'note2'],
+        ['Alice', 'Cust1', 'Asm1', 'R1', 'J100', 10, 1, 'note1'],
+        ['Bob', 'Cust2', 'Asm2', 'R2', 'J200', 20, 2, 'note2'],
     ]
     file = tmp_path / 'aoi.xlsx'
     pd.DataFrame(data).to_excel(file, header=False, index=False)
     rows = parse_aoi_rows(str(file))
     assert rows[0]['operator'] == 'Alice'
     assert rows[1]['qty_rejected'] == 2
+    assert rows[0]['rev'] == 'R1'
 
 
 @pytest.fixture()
@@ -30,12 +31,12 @@ def client(tmp_path, monkeypatch):
         ('tester', 'pw')
     )
     data = [
-        ('2024-01-01', '1st', 'Alice', 'Cust1', 'Asm1', 10, 1, ''),
-        ('2024-01-02', '1st', 'Alice', 'Cust1', 'Asm1', 15, 0, ''),
-        ('2024-01-01', '2nd', 'Bob', 'Cust2', 'Asm2', 20, 2, ''),
+        ('2024-01-01', '1st', 'Alice', 'Cust1', 'Asm1', 'R1', 'J100', 10, 1, ''),
+        ('2024-01-02', '1st', 'Alice', 'Cust1', 'Asm1', 'R1', 'J100', 15, 0, ''),
+        ('2024-01-01', '2nd', 'Bob', 'Cust2', 'Asm2', 'R2', 'J200', 20, 2, ''),
     ]
     conn.executemany(
-        "INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?)",
+        "INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
         data,
     )
     conn.commit()


### PR DESCRIPTION
## Summary
- allow tracking Rev and JobNumber on AOI daily reports
- expose Rev/JobNumber fields in entry form and table display
- add standard deviation histogram for false-call rates in PPM MOAT analysis

## Testing
- `export SECRET_KEY=test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a708a62de48325a200497c6b6ec75c