### PR TITLE
Add report toolbar undo/clear buttons and customer reject std chart

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -246,6 +246,15 @@ table thead th {
   color: var(--color-white);
   margin-left: 5px;
   cursor: pointer;
+  width: 30px;
+  height: 30px;
+  font-size: 16px;
+  border-radius: 4px;
+}
+
+.report-window-header button:hover {
+  background: var(--color-white);
+  color: var(--color-accent);
 }
 
 .report-window-body {

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -114,6 +114,52 @@ window.addEventListener('DOMContentLoaded', () => {
         options: { scales: { y: { beginAtZero: true } } }
       });
     }
+
+    const stdCtx = document.getElementById('customerStdChart');
+    if (stdCtx) {
+      const rates = customerData.map(c => c.rate);
+      const yMax = Math.max(...rates, 1);
+      const bins = 10;
+      const binWidth = yMax / bins;
+      const counts = Array(bins).fill(0);
+      rates.forEach(r => {
+        const idx = Math.min(Math.floor(r / binWidth), bins - 1);
+        counts[idx]++;
+      });
+      const labels = counts.map((_, i) => `${(i * binWidth).toFixed(1)}-${((i + 1) * binWidth).toFixed(1)}`);
+      const mean = rates.reduce((a, b) => a + b, 0) / rates.length;
+      const variance = rates.reduce((a, b) => a + (b - mean) ** 2, 0) / rates.length;
+      const stdev = Math.sqrt(variance);
+      const total = rates.length;
+      const xVals = counts.map((_, i) => i * binWidth + binWidth / 2);
+      const norm = xVals.map(x => (1 / (stdev * Math.sqrt(2 * Math.PI))) * Math.exp(-0.5 * ((x - mean) ** 2) / (stdev ** 2)) * total * binWidth);
+      new Chart(stdCtx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Frequency',
+              data: counts,
+              backgroundColor: 'rgba(54, 162, 235, 0.7)',
+              borderColor: 'rgba(54, 162, 235, 1)'
+            },
+            {
+              type: 'line',
+              label: 'Normal Dist',
+              data: norm,
+              borderColor: 'rgba(255, 99, 132, 1)',
+              fill: false,
+              tension: 0.4,
+              pointRadius: 0
+            }
+          ]
+        },
+        options: { scales: { y: { beginAtZero: true } } }
+      });
+      const summaryEl = document.getElementById('customerStdChartSummary');
+      if (summaryEl) summaryEl.textContent = `Mean rate ${mean.toFixed(2)} with std dev ${stdev.toFixed(2)}.`;
+    }
   }
 
   const yieldData = getData('yield-data');

--- a/static/js/report_window.js
+++ b/static/js/report_window.js
@@ -57,21 +57,25 @@
 
     const header = document.createElement('div');
     header.className = 'report-window-header';
-    header.innerHTML = '<button id="report-add-text">Add Text</button>' +
-      '<button id="report-add-h1">Add Header 1</button>' +
-      '<button id="report-add-h2">Add Header 2</button>' +
+    header.innerHTML =
+      '<button id="report-add-text" title="Add Text">📝</button>' +
+      '<button id="report-add-h1" title="Add Header 1">H1</button>' +
+      '<button id="report-add-h2" title="Add Header 2">H2</button>' +
+      '<button id="report-undo" title="Undo Last">↩</button>' +
+      '<button id="report-clear" title="Clear All">🗑</button>' +
       '<label>Margin:<select id="report-margin">' +
-      '<option value="0.25">0.25\"</option>' +
-      '<option value="0.5" selected>0.5\"</option>' +
-      '<option value="0.75">0.75\"</option>' +
-      '<option value="1">1\"</option>' +
+      '<option value="0.25">0.25"</option>' +
+      '<option value="0.5" selected>0.5"</option>' +
+      '<option value="0.75">0.75"</option>' +
+      '<option value="1">1"</option>' +
       '</select></label>' +
-      '<div class="right"><button id="report-print">Print</button>' +
+      '<div class="right"><button id="report-print" title="Print">🖨</button>' +
       '<button id="report-close" title="Close">\u00d7</button></div>';
 
     const body = document.createElement('div');
     body.className = 'report-window-body';
 
+    const history = [];
     const marginSelect = header.querySelector('#report-margin');
 
     function createPage() {
@@ -204,6 +208,22 @@
     marginSelect.addEventListener('change', () => applyMargin(true));
     applyMargin(true);
 
+    header.querySelector('#report-undo').addEventListener('click', () => {
+      const last = history.pop();
+      if (last && last.parentNode) {
+        last.remove();
+        reflowPages();
+        save();
+      }
+    });
+
+    header.querySelector('#report-clear').addEventListener('click', () => {
+      body.innerHTML = '';
+      body.appendChild(createPage());
+      history.length = 0;
+      save();
+    });
+
     header.querySelector('#report-close').addEventListener('click', () => {
       win.remove();
       disableDraggables();
@@ -220,6 +240,7 @@
       makeReportItemResizable(wrapper);
       makeReportItemDraggable(wrapper);
       addToPage(wrapper);
+      history.push(wrapper);
       el.focus();
       el.addEventListener('keydown', e => {
         if (e.key === 'Enter') {
@@ -264,6 +285,7 @@
       makeReportItemResizable(wrapper);
       makeReportItemDraggable(wrapper);
       addToPage(wrapper);
+      history.push(wrapper);
     });
 
     header.querySelector('#report-print').addEventListener('click', async () => {

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -145,6 +145,9 @@
           <canvas id="shiftChart"></canvas>
           <h2>Operator Reject Rates per Customer <button class="expand-chart" data-chart="customer">Expand</button></h2>
           <canvas id="customerChart"></canvas>
+          <h2>Std Dev of Reject Rates per Customer</h2>
+          <canvas id="customerStdChart"></canvas>
+          <p id="customerStdChartSummary" class="chart-summary"></p>
           <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield">Expand</button></h2>
           <canvas id="yieldChart"></canvas>
           <h2>Performance per Assembly</h2>


### PR DESCRIPTION
## Summary
- convert Generate Report toolbar to icon buttons and add undo/clear actions
- include histogram + normal distribution of reject rates per customer in AOI Daily Report
- style report toolbar buttons with hover feedback

## Testing
- `SECRET_KEY=dev pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a70e4ac82083259f02beba75474479