### PR TITLE
Enhance histogram detail on standard deviation charts

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -498,7 +498,7 @@ window.addEventListener('DOMContentLoaded', () => {
             chartStdModal.style.display = 'block';
             return;
           }
-          const bins = 10;
+          const bins = 20; // more bins for clearer distribution
           const binWidth = yMax / bins;
           const counts = Array(bins).fill(0);
           rates.forEach(rate => {
@@ -571,7 +571,7 @@ window.addEventListener('DOMContentLoaded', () => {
             chartNgStdModal.style.display = 'block';
             return;
           }
-          const bins = 10;
+          const bins = 20; // more bins for clearer distribution
           const binWidth = yMax / bins;
           const counts = Array(bins).fill(0);
           rates.forEach(rate => {

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -119,14 +119,15 @@ window.addEventListener('DOMContentLoaded', () => {
     if (stdCtx) {
       const rates = customerData.map(c => c.rate);
       const yMax = Math.max(...rates, 1);
-      const bins = 10;
+      const bins = 20; // increased bins for finer resolution
       const binWidth = yMax / bins;
       const counts = Array(bins).fill(0);
       rates.forEach(r => {
         const idx = Math.min(Math.floor(r / binWidth), bins - 1);
         counts[idx]++;
       });
-      const labels = counts.map((_, i) => `${(i * binWidth).toFixed(1)}-${((i + 1) * binWidth).toFixed(1)}`);
+      const decimals = binWidth < 1 ? 2 : 1;
+      const labels = counts.map((_, i) => `${(i * binWidth).toFixed(decimals)}-${((i + 1) * binWidth).toFixed(decimals)}`);
       const mean = rates.reduce((a, b) => a + b, 0) / rates.length;
       const variance = rates.reduce((a, b) => a + (b - mean) ** 2, 0) / rates.length;
       const stdev = Math.sqrt(variance);


### PR DESCRIPTION
## Summary
- Increase histogram bins to 20 for AOI daily report standard deviation chart, with adaptive labels for finer X axis
- Increase bins to 20 in PPM MOAT false call and NG rate standard deviation charts for improved curve visibility

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a712723a84832589af58e3826d4122