### PR TITLE
Add expand icon and statistical lines for AOI charts

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -147,7 +147,11 @@ table thead th {
 
 .expand-chart {
   margin-left: 8px;
-  font-size: 0.8em;
+  font-size: 1em;
+  background: none;
+  border: none;
+  cursor: pointer;
+  vertical-align: middle;
 }
 
 .action-card p {

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -29,6 +29,95 @@ window.addEventListener('DOMContentLoaded', () => {
     return el ? JSON.parse(el.textContent) : null;
   };
 
+  const verticalLinePlugin = {
+    id: 'verticalLines',
+    afterDraw(chart, args, opts) {
+      const {ctx, chartArea: {top, bottom}, scales: {x}} = chart;
+      (opts.lines || []).forEach(line => {
+        const xPos = x.getPixelForValue(line.value);
+        ctx.save();
+        ctx.strokeStyle = line.color || 'black';
+        ctx.beginPath();
+        ctx.moveTo(xPos, top);
+        ctx.lineTo(xPos, bottom);
+        ctx.stroke();
+        if (line.label) {
+          ctx.fillStyle = line.color || 'black';
+          ctx.textBaseline = 'top';
+          ctx.fillText(line.label, xPos + 4, top + 12);
+        }
+        ctx.restore();
+      });
+    }
+  };
+
+  function createStdConfig(data) {
+    const rates = data.map(c => c.rate);
+    const yMax = Math.max(...rates, 1);
+    const bins = 20;
+    const binWidth = yMax / bins;
+    const counts = Array(bins).fill(0);
+    rates.forEach(r => {
+      const idx = Math.min(Math.floor(r / binWidth), bins - 1);
+      counts[idx]++;
+    });
+    const decimals = binWidth < 1 ? 2 : 1;
+    const labels = counts.map((_, i) => `${(i * binWidth).toFixed(decimals)}-${((i + 1) * binWidth).toFixed(decimals)}`);
+    const total = rates.length;
+    const avg = rates.reduce((a, b) => a + b, 0) / total;
+    const mean = avg;
+    const variance = rates.reduce((a, b) => a + (b - mean) ** 2, 0) / total;
+    const stdev = Math.sqrt(variance);
+    const xVals = counts.map((_, i) => i * binWidth + binWidth / 2);
+    const norm = xVals.map(x => (1 / (stdev * Math.sqrt(2 * Math.PI))) * Math.exp(-0.5 * ((x - mean) ** 2) / (stdev ** 2)) * total * binWidth);
+    const lines = [
+      { value: avg, color: 'green', label: `Avg = ${avg.toFixed(2)}` },
+      { value: mean, color: 'blue', label: `Mean = ${mean.toFixed(2)}` },
+      { value: mean + stdev, color: 'red', label: '1σ' },
+      { value: mean + 2 * stdev, color: 'red', label: '2σ' },
+      { value: mean + 3 * stdev, color: 'red', label: '3σ' },
+      { value: mean - stdev, color: 'red', label: '-1σ' },
+      { value: mean - 2 * stdev, color: 'red', label: '-2σ' },
+      { value: mean - 3 * stdev, color: 'red', label: '-3σ' }
+    ];
+    const xMax = Math.max(...rates, mean + 3 * stdev);
+    const config = {
+      type: 'bar',
+      data: {
+        datasets: [
+          {
+            label: 'Frequency',
+            data: xVals.map((x, i) => ({ x, y: counts[i] })),
+            backgroundColor: 'rgba(54, 162, 235, 0.7)',
+            borderColor: 'rgba(54, 162, 235, 1)',
+            parsing: false
+          },
+          {
+            type: 'line',
+            label: 'Normal Dist',
+            data: xVals.map((x, i) => ({ x, y: norm[i] })),
+            borderColor: 'rgba(255, 99, 132, 1)',
+            fill: false,
+            tension: 0.4,
+            pointRadius: 0,
+            parsing: false
+          }
+        ]
+      },
+      options: {
+        scales: {
+          x: { type: 'linear', min: 0, max: xMax },
+          y: { beginAtZero: true }
+        },
+        plugins: { verticalLines: { lines } }
+      },
+      plugins: [verticalLinePlugin]
+    };
+    const rows = counts.map((c, i) => [labels[i], c]);
+    const summary = `Mean rate ${mean.toFixed(2)} with std dev ${stdev.toFixed(2)}.`;
+    return { config, rows, summary };
+  }
+
   const ops = getData('operator-data');
   const isAdmin = document.body.dataset.admin === 'true';
   if (ops && ops.length) {
@@ -114,52 +203,12 @@ window.addEventListener('DOMContentLoaded', () => {
         options: { scales: { y: { beginAtZero: true } } }
       });
     }
-
     const stdCtx = document.getElementById('customerStdChart');
     if (stdCtx) {
-      const rates = customerData.map(c => c.rate);
-      const yMax = Math.max(...rates, 1);
-      const bins = 20; // increased bins for finer resolution
-      const binWidth = yMax / bins;
-      const counts = Array(bins).fill(0);
-      rates.forEach(r => {
-        const idx = Math.min(Math.floor(r / binWidth), bins - 1);
-        counts[idx]++;
-      });
-      const decimals = binWidth < 1 ? 2 : 1;
-      const labels = counts.map((_, i) => `${(i * binWidth).toFixed(decimals)}-${((i + 1) * binWidth).toFixed(decimals)}`);
-      const mean = rates.reduce((a, b) => a + b, 0) / rates.length;
-      const variance = rates.reduce((a, b) => a + (b - mean) ** 2, 0) / rates.length;
-      const stdev = Math.sqrt(variance);
-      const total = rates.length;
-      const xVals = counts.map((_, i) => i * binWidth + binWidth / 2);
-      const norm = xVals.map(x => (1 / (stdev * Math.sqrt(2 * Math.PI))) * Math.exp(-0.5 * ((x - mean) ** 2) / (stdev ** 2)) * total * binWidth);
-      new Chart(stdCtx, {
-        type: 'bar',
-        data: {
-          labels,
-          datasets: [
-            {
-              label: 'Frequency',
-              data: counts,
-              backgroundColor: 'rgba(54, 162, 235, 0.7)',
-              borderColor: 'rgba(54, 162, 235, 1)'
-            },
-            {
-              type: 'line',
-              label: 'Normal Dist',
-              data: norm,
-              borderColor: 'rgba(255, 99, 132, 1)',
-              fill: false,
-              tension: 0.4,
-              pointRadius: 0
-            }
-          ]
-        },
-        options: { scales: { y: { beginAtZero: true } } }
-      });
+      const { config, summary } = createStdConfig(customerData);
+      new Chart(stdCtx, config);
       const summaryEl = document.getElementById('customerStdChartSummary');
-      if (summaryEl) summaryEl.textContent = `Mean rate ${mean.toFixed(2)} with std dev ${stdev.toFixed(2)}.`;
+      if (summaryEl) summaryEl.textContent = summary;
     }
   }
 
@@ -291,6 +340,9 @@ window.addEventListener('DOMContentLoaded', () => {
         };
         const rows = customerData.map(c => [c.customer, c.rate]);
         showModal('Operator Reject Rates', config, ['Customer','Reject Rate'], rows);
+      } else if (type === 'customer-std' && customerData) {
+        const { config, rows } = createStdConfig(customerData);
+        showModal('Std Dev of Reject Rates per Customer', config, ['Range','Frequency'], rows);
       } else if (type === 'yield' && yieldData) {
         const config = {
           type: 'line',

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -139,16 +139,16 @@
               <button type="submit">Apply</button>
             </form>
           </div>
-          <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators">Expand</button></h2>
+          <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators" aria-label="Expand chart">⤢</button></h2>
           <canvas id="operatorsChart"></canvas>
-          <h2>Shift Totals <button class="expand-chart" data-chart="shift">Expand</button></h2>
+          <h2>Shift Totals <button class="expand-chart" data-chart="shift" aria-label="Expand chart">⤢</button></h2>
           <canvas id="shiftChart"></canvas>
-          <h2>Operator Reject Rates per Customer <button class="expand-chart" data-chart="customer">Expand</button></h2>
+          <h2>Operator Reject Rates per Customer <button class="expand-chart" data-chart="customer" aria-label="Expand chart">⤢</button></h2>
           <canvas id="customerChart"></canvas>
-          <h2>Std Dev of Reject Rates per Customer</h2>
+          <h2>Std Dev of Reject Rates per Customer <button class="expand-chart" data-chart="customer-std" aria-label="Expand chart">⤢</button></h2>
           <canvas id="customerStdChart"></canvas>
           <p id="customerStdChartSummary" class="chart-summary"></p>
-          <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield">Expand</button></h2>
+          <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield" aria-label="Expand chart">⤢</button></h2>
           <canvas id="yieldChart"></canvas>
           <h2>Performance per Assembly</h2>
           <table id="assemblyTable">


### PR DESCRIPTION
## Summary
- convert AOI chart expand buttons to icon buttons and add one for the standard deviation chart
- draw Avg, Mean, and ±σ lines on the standard deviation histogram with labels
- support expanding the standard deviation chart in the modal view

## Testing
- `SECRET_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7152305c48325859ce10ebe79f3fd