### PR TITLE
Add reusable std deviation charts with downloads

### DIFF
--- a/static/js/std_chart.js
+++ b/static/js/std_chart.js
@@ -1,0 +1,82 @@
+(function(){
+  const verticalLinePlugin = {
+    id: 'verticalLines',
+    afterDraw(chart, args, opts) {
+      const {ctx, chartArea: {top, bottom}, scales: {x}} = chart;
+      (opts.lines || []).forEach(line => {
+        const xPos = x.getPixelForValue(line.value);
+        ctx.save();
+        ctx.strokeStyle = line.color || 'black';
+        ctx.beginPath();
+        ctx.moveTo(xPos, top);
+        ctx.lineTo(xPos, bottom);
+        ctx.stroke();
+        if (line.label) {
+          ctx.fillStyle = line.color || 'black';
+          ctx.textBaseline = 'top';
+          ctx.fillText(line.label, xPos + 4, top + 12);
+        }
+        ctx.restore();
+      });
+    }
+  };
+
+  window.createStdChartConfig = function(rates, mean, stdev, yMax, options={}) {
+    const bins = options.bins || 20;
+    const binWidth = yMax / bins;
+    const counts = Array(bins).fill(0);
+    rates.forEach(r => {
+      const idx = Math.min(Math.floor(r / binWidth), bins - 1);
+      counts[idx]++;
+    });
+    const decimals = options.decimals !== undefined ? options.decimals : (binWidth < 1 ? 2 : 1);
+    const labels = counts.map((_, i) => `${(i * binWidth).toFixed(decimals)}-${((i + 1) * binWidth).toFixed(decimals)}`);
+    const total = rates.length;
+    const xVals = counts.map((_, i) => i * binWidth + binWidth / 2);
+    const norm = xVals.map(x => (1 / (stdev * Math.sqrt(2 * Math.PI))) * Math.exp(-0.5 * ((x - mean) ** 2) / (stdev ** 2)) * total * binWidth);
+    const sigmaColor = options.sigmaColor || 'red';
+    const lines = [
+      { value: mean, color: options.avgColor || 'green', label: `Avg = ${mean.toFixed(decimals)}` },
+      { value: mean + stdev, color: sigmaColor, label: '+1\u03C3' },
+      { value: mean + 2 * stdev, color: sigmaColor, label: '+2\u03C3' },
+      { value: mean + 3 * stdev, color: sigmaColor, label: '+3\u03C3' },
+      { value: mean - stdev, color: sigmaColor, label: '-1\u03C3' },
+      { value: mean - 2 * stdev, color: sigmaColor, label: '-2\u03C3' },
+      { value: mean - 3 * stdev, color: sigmaColor, label: '-3\u03C3' }
+    ];
+    const config = {
+      type: 'bar',
+      data: {
+        datasets: [
+          {
+            label: 'Frequency',
+            data: xVals.map((x, i) => ({ x, y: counts[i] })),
+            backgroundColor: options.barColor || 'rgba(54, 162, 235, 0.7)',
+            borderColor: options.barBorderColor || 'rgba(54, 162, 235, 1)',
+            parsing: false
+          },
+          {
+            type: 'line',
+            label: 'Normal Dist',
+            data: xVals.map((x, i) => ({ x, y: norm[i] })),
+            borderColor: options.lineColor || 'rgba(255, 99, 132, 1)',
+            fill: false,
+            tension: 0.4,
+            pointRadius: 0,
+            parsing: false
+          }
+        ]
+      },
+      options: {
+        scales: {
+          x: { type: 'linear', min: 0, max: yMax },
+          y: { beginAtZero: true }
+        },
+        plugins: { verticalLines: { lines } }
+      },
+      plugins: [verticalLinePlugin]
+    };
+    const rows = counts.map((c, i) => [labels[i], c]);
+    return { config, rows };
+  };
+})();

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -10,6 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
     <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/std_chart.js') }}" defer></script>
     <script src="/static/js/analysis.js" defer></script>
     <script src="{{ url_for('static', filename='js/moat_sql.js') }}" defer></script>
 {% endblock %}
@@ -516,6 +517,16 @@
         <h2>Std Dev - Avg FC per Assembly</h2>
         <canvas id="chart-stddev-canvas" height="200"></canvas>
         <p id="stddev-chart-summary" class="chart-summary"></p>
+        <table id="std-data-table"></table>
+        <label>Margin:
+          <select id="std-margin">
+            <option value="0.25">0.25"</option>
+            <option value="0.5" selected>0.5"</option>
+            <option value="0.75">0.75"</option>
+            <option value="1">1"</option>
+          </select>
+        </label>
+        <button id="download-std-pdf">Download PDF</button>
       </div>
     </div>
     <div id="chart-ng-stddev-modal" class="modal">
@@ -524,6 +535,16 @@
         <h2>Std Dev - Avg NG per Assembly</h2>
         <canvas id="chart-ng-stddev-canvas" height="200"></canvas>
         <p id="ng-stddev-chart-summary" class="chart-summary"></p>
+        <table id="ng-std-data-table"></table>
+        <label>Margin:
+          <select id="ng-std-margin">
+            <option value="0.25">0.25"</option>
+            <option value="0.5" selected>0.5"</option>
+            <option value="0.75">0.75"</option>
+            <option value="1">1"</option>
+          </select>
+        </label>
+        <button id="download-ng-std-pdf">Download PDF</button>
       </div>
     </div>
   {% endif %}

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -15,6 +15,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.plugin.jpeg.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js" defer></script>
   <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/std_chart.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_dashboard.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_sql.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- Build reusable standard deviation chart config with avg and sigma lines
- Integrate std chart builder into MOAT and AOI pages and drop Mean label
- Allow downloading MOAT std dev charts with adjustable margins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7173dce9c8325ad4065babc724319