### PR TITLE
Enhance tab styling with hover descriptions

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -372,16 +372,23 @@ table thead th {
 }
 
 .tab-nav button {
+  flex: 1;
   background: var(--color-accent);
   color: var(--color-white);
   border: none;
-  padding: 8px 12px;
+  padding: 10px;
   cursor: pointer;
+  text-align: center;
+  transition: background 0.3s ease;
 }
 
 .tab-nav button.active {
   background: var(--color-black);
   color: var(--color-white);
+}
+
+.tab-nav button:hover {
+  background: var(--color-black);
 }
 
 .tab-content {
@@ -390,6 +397,24 @@ table thead th {
 
 .tab-content.active {
   display: block;
+}
+
+.tab-hover-info {
+  background: var(--color-accent);
+  color: var(--color-white);
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+  padding: 0 10px;
+}
+
+.tab-hover-info.show {
+  max-height: 200px;
+  padding: 10px;
+}
+
+.tab-hover-info details {
+  margin-top: 5px;
 }
 
 .home-title img {

--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -15,5 +15,31 @@ document.addEventListener('DOMContentLoaded', () => {
         if (target) target.classList.add('active');
       });
     });
+
+    const info = document.createElement('div');
+    info.className = 'tab-hover-info';
+    nav.insertAdjacentElement('afterend', info);
+    let hideTimeout;
+
+    links.forEach(link => {
+      link.addEventListener('mouseenter', () => {
+        const desc = link.dataset.desc || '';
+        const more = link.dataset.more || '';
+        info.innerHTML = `<p>${desc}</p>${more ? `<details><summary>Read more</summary><p>${more}</p></details>` : ''}`;
+        info.classList.add('show');
+      });
+    });
+
+    nav.addEventListener('mouseleave', () => {
+      hideTimeout = setTimeout(() => info.classList.remove('show'), 100);
+    });
+
+    info.addEventListener('mouseenter', () => {
+      clearTimeout(hideTimeout);
+    });
+
+    info.addEventListener('mouseleave', () => {
+      info.classList.remove('show');
+    });
   });
 });

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -32,8 +32,8 @@
     <div id="container">
       <div id="analysis-actions">
         <nav class="tab-nav">
-          <button class="tab-link active" data-tab="actions-tab">Actions</button>
-          <button class="tab-link" data-tab="reports-tab">Reports</button>
+          <button class="tab-link active" data-tab="actions-tab" data-desc="Upload and chart PPM reports." data-more="Import reports and configure control charts to analyze false call rates.">Actions</button>
+          <button class="tab-link" data-tab="reports-tab" data-desc="Browse uploaded reports." data-more="View previously uploaded PPM reports and export data.">Reports</button>
         </nav>
         <div id="actions-tab" class="tab-content active">
           <div class="action-panel">

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -26,10 +26,10 @@
   <div id="container">
     <div id="aoi-actions">
       <nav class="tab-nav">
-        <button class="tab-link active" data-tab="add-entry">Add Entry</button>
-        <button class="tab-link" data-tab="analysis">AOI Analysis</button>
-        <button class="tab-link" data-tab="reports">Reports</button>
-        <button class="tab-link" data-tab="sql">SQL</button>
+        <button class="tab-link active" data-tab="add-entry" data-desc="Record new inspection entry." data-more="Use this tab to log AOI inspection data individually or in bulk.">Add Entry</button>
+        <button class="tab-link" data-tab="analysis" data-desc="Review AOI inspection trends." data-more="Analyze defect rates and other metrics to improve processes.">AOI Analysis</button>
+        <button class="tab-link" data-tab="reports" data-desc="Generate and export summary reports." data-more="Create PDF summaries of inspections for distribution.">Reports</button>
+        <button class="tab-link" data-tab="sql" data-desc="Run custom queries on AOI data." data-more="Use SQL to directly access underlying inspection records.">SQL</button>
       </nav>
       <div id="add-entry" class="tab-content active">
         <div class="action-panel">

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -26,10 +26,10 @@
   <div id="container">
     <div id="aoi-actions">
       <nav class="tab-nav">
-        <button class="tab-link active" data-tab="add-entry">Add Entry</button>
-        <button class="tab-link" data-tab="analysis">Final Inspect Analysis</button>
-        <button class="tab-link" data-tab="reports">Reports</button>
-        <button class="tab-link" data-tab="sql">SQL</button>
+        <button class="tab-link active" data-tab="add-entry" data-desc="Record new inspection results." data-more="Log final inspect data individually or through bulk upload.">Add Entry</button>
+        <button class="tab-link" data-tab="analysis" data-desc="Review final inspection metrics." data-more="Analyze yields and defect trends to monitor quality.">Final Inspect Analysis</button>
+        <button class="tab-link" data-tab="reports" data-desc="Generate and export summary reports." data-more="Create PDF summaries of inspections for distribution.">Reports</button>
+        <button class="tab-link" data-tab="sql" data-desc="Run custom queries on final inspect data." data-more="Use SQL to directly access underlying inspection records.">SQL</button>
       </nav>
       <div id="add-entry" class="tab-content active">
         <div class="action-panel">


### PR DESCRIPTION
## Summary
- Make tab buttons equal width and add smooth hover reveal panel
- Add hover details for each tab across AOI, Final Inspect, and Analysis pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72301c0948325b5ca0510886365b4