### PR TITLE
Use report date for MOAT range

### DIFF
--- a/run.py
+++ b/run.py
@@ -14,7 +14,7 @@ from functools import wraps
 import os
 import sqlite3
 import pandas as pd
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 import re
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
@@ -1453,9 +1453,16 @@ def analysis():
 
         total_rows = len(rows)
         if total_rows:
-            times = [datetime.fromisoformat(r['upload_time']) for r in rows]
-            earliest = min(times).date().isoformat()
-            latest = max(times).date().isoformat()
+            report_dates = [
+                date.fromisoformat(r['report_date'])
+                for r in rows
+                if r['report_date']
+            ]
+            if report_dates:
+                earliest = min(report_dates).isoformat()
+                latest = max(report_dates).isoformat()
+            else:
+                earliest = latest = ''
         else:
             earliest = latest = ''
     else:

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -22,7 +22,7 @@
   {% else %}
     <div class="moat-stats">
       {% if total_rows %}
-        Total rows: {{ total_rows }} | Table range: {{ earliest }} - {{ latest }}
+        Total rows: {{ total_rows }} | Report date range: {{ earliest }} - {{ latest }}
         {% if is_admin or permissions['analysis'] %}
         &nbsp;|&nbsp;
         <button id="show-uploads-btn" title="View or delete previously uploaded reports">Manage Uploads</button>


### PR DESCRIPTION
## Summary
- derive earliest and latest MOAT report dates from the `report_date` column
- show report date range in analysis page summary

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8445797908325b8d520204e9ad5c2