### PR TITLE
Use report_date for analysis report periods

### DIFF
--- a/run.py
+++ b/run.py
@@ -1596,23 +1596,23 @@ def analysis_report_data():
         return jsonify(error='Invalid frequency'), 400
 
     conn = get_db()
-    end_row = conn.execute('SELECT MAX(upload_time) AS max_time FROM moat').fetchone()
-    if not end_row or not end_row['max_time']:
+    end_row = conn.execute('SELECT MAX(report_date) AS max_date FROM moat').fetchone()
+    if not end_row or not end_row['max_date']:
         conn.close()
         return jsonify(labels=[], falsecall_ppm=[], ng_ppm=[], table=[])
 
-    end_date = datetime.fromisoformat(end_row['max_time']).date()
+    end_date = date.fromisoformat(end_row['max_date'])
     start_date = end_date - timedelta(days=delta - 1)
-    params = [f'{start_date.isoformat()}T00:00:00', f'{end_date.isoformat()}T23:59:59']
+    params = [start_date.isoformat(), end_date.isoformat()]
 
     rows = conn.execute(
         f"""
-        SELECT strftime('{group}', upload_time) AS period,
+        SELECT strftime('{group}', report_date) AS period,
                SUM(total_boards) AS boards,
                SUM(falsecall_parts)*1000000.0/SUM(total_parts) AS fc_ppm,
                SUM(ng_parts)*1000000.0/SUM(total_parts) AS ng_ppm
         FROM moat
-        WHERE upload_time BETWEEN ? AND ?
+        WHERE report_date BETWEEN ? AND ?
         GROUP BY period
         ORDER BY period
         """,

--- a/tests/test_analysis_report_data.py
+++ b/tests/test_analysis_report_data.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from run import app, init_db, get_db
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, analysis, reports) VALUES (?,?,1,1)",
+        ('tester', 'pw')
+    )
+    conn.execute(
+        "INSERT INTO moat (model_name, total_boards, total_parts_per_board, total_parts, ng_parts, ng_ppm, falsecall_parts, falsecall_ppm, upload_time, report_date) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ('MODEL1', 1, 1, 1, 0, 0.0, 0, 0.0, '2025-01-01T00:00:00', '2023-01-01')
+    )
+    conn.commit()
+    conn.close()
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user'] = 'tester'
+        yield client
+
+
+@pytest.mark.parametrize("freq,expected", [
+    ("daily", "2023-01-01"),
+    ("weekly", "2023-00"),
+    ("monthly", "2023-01"),
+    ("yearly", "2023"),
+])
+def test_analysis_report_data_uses_report_date(client, freq, expected):
+    resp = client.get(f'/analysis/report-data?freq={freq}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['labels'] == [expected]


### PR DESCRIPTION
## Summary
- Use `report_date` instead of `upload_time` when computing max dates, grouping, and filtering in `/analysis/report-data`.
- Add tests verifying daily/weekly/monthly/yearly aggregations use `report_date`.

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8450ce4388325a4039f83564b3b7f