### PR TITLE
Use report date for MOAT upload column

### DIFF
--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -443,8 +443,7 @@
           <thead><tr>
             <th>Model Name</th><th>Total Boards</th><th>Total Parts/Board</th>
             <th>Total Parts</th><th>NG Parts</th><th>NG PPM</th>
-            <th>FalseCall Parts</th><th>FalseCall PPM</th><th>Upload Time</th>
-            <th>Report Date</th><th>Line</th>
+            <th>FalseCall Parts</th><th>FalseCall PPM</th><th>Report Date</th><th>Line</th>
           </tr></thead>
           <tbody>
           {% for row in moat %}
@@ -457,7 +456,6 @@
             <td>{{ row['ng_ppm'] }}</td>
             <td>{{ row['falsecall_parts'] }}</td>
             <td>{{ row['falsecall_ppm'] }}</td>
-            <td>{{ row['upload_time'] }}</td>
             <td>{{ row['report_date'] }}</td>
             <td>{{ row['line'] }}</td>
           </tr>


### PR DESCRIPTION
## Summary
- Show PPM report's report date instead of upload time in MOAT table

## Testing
- `SECRET_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84691cf948325a0e9fec6ea33d82c