### PR TITLE
Order MOAT data and charts by report date

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -258,7 +258,7 @@ window.addEventListener('DOMContentLoaded', () => {
       fetch(`/analysis/chart-data?start=${start}&end=${end}&threshold=${threshold}&metric=fc${lineQuery}${modelQuery}${filterQuery}`)
         .then(res => res.json())
         .then(data => {
-          const labels = data.map(d => d.model);
+          const labels = data.map(d => `${d.report_date} ${d.model}`);
           const inRangeValues = data.map(d => (d.rate <= yMax ? d.rate : null));
           const outliers = data.filter(d => d.rate > yMax);
           if (chartInstance) chartInstance.destroy();
@@ -289,7 +289,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 {
                   type: 'scatter',
                   label: 'Outliers',
-                  data: outliers.map(d => ({ x: d.model, y: yMax, real: d.rate })),
+                  data: outliers.map(d => ({ x: `${d.report_date} ${d.model}`, y: yMax, real: d.rate })),
                   borderColor: 'red',
                   pointBackgroundColor: 'red',
                   pointBorderColor: 'red',
@@ -383,7 +383,7 @@ window.addEventListener('DOMContentLoaded', () => {
       fetch(`/analysis/chart-data?start=${start}&end=${end}&threshold=${threshold}&metric=ng${lineQuery}${modelQuery}${filterQuery}`)
         .then(res => res.json())
         .then(data => {
-          const labels = data.map(d => d.model);
+          const labels = data.map(d => `${d.report_date} ${d.model}`);
           const inRangeValues = data.map(d => (d.rate <= yMax ? d.rate : null));
           const outliers = data.filter(d => d.rate > yMax);
           if (ngChartInstance) ngChartInstance.destroy();
@@ -414,7 +414,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 {
                   type: 'scatter',
                   label: 'Outliers',
-                  data: outliers.map(d => ({ x: d.model, y: yMax, real: d.rate })),
+                  data: outliers.map(d => ({ x: `${d.report_date} ${d.model}`, y: yMax, real: d.rate })),
                   borderColor: 'red',
                   pointBackgroundColor: 'red',
                   pointBorderColor: 'red',


### PR DESCRIPTION
## Summary
- Sort MOAT table by report date, newest first
- Return chart data ordered by report date and include report_date field
- Display control chart points by report date

## Testing
- `export SECRET_KEY='test' && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84868ac9883259a68929a8dffd60d