### PR TITLE
Add AOI vs Final Inspect comparison entry point

### DIFF
--- a/run.py
+++ b/run.py
@@ -1721,6 +1721,12 @@ def moat_sql():
     return jsonify(rows=rows)
 
 
+@app.route('/aoi-fi-compare')
+@login_required
+def aoi_fi_compare():
+    return render_template('aoi_fi_compare.html')
+
+
 @app.route('/sap/material/<material_id>')
 @login_required
 def sap_material(material_id):

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -18,7 +18,10 @@
   <a href="/">← Home</a>
   <h1>Data Analysis - PPM MOAT</h1>
   {% if not show_moat %}
-    <button onclick="window.location='{{ url_for('analysis') }}?view=moat'">View PPM Reports</button>
+    <div style="display:flex; flex-direction:column; gap:10px; width:fit-content;">
+      <button onclick="window.location='{{ url_for('analysis') }}?view=moat'">View PPM Reports</button>
+      <button onclick="window.location='{{ url_for('aoi_fi_compare') }}'">Compare AOI vs Final Inspect</button>
+    </div>
   {% else %}
     <div class="moat-stats">
       {% if total_rows %}

--- a/templates/aoi_fi_compare.html
+++ b/templates/aoi_fi_compare.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}AOI vs Final Inspect Comparison{% endblock %}
+{% block content %}
+  <a href="{{ url_for('analysis') }}">← Back to Analysis</a>
+  <h1>AOI vs Final Inspect Comparison</h1>
+  <p>Coming soon.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add new "Compare AOI vs Final Inspect" button on analysis page
- Provide placeholder route and template for AOI vs Final Inspect comparison

## Testing
- `SECRET_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a87f63a6ac8325b531531a471abc9a