### PR TITLE
Ensure AOI/FI comparison uses plain dict rows

### DIFF
--- a/run.py
+++ b/run.py
@@ -1783,6 +1783,7 @@ def compare_aoi_fi():
         raw_params.append(end)
     aoi_raw_query += ' ORDER BY report_date DESC, id DESC'
     aoi_rows = conn.execute(aoi_raw_query, raw_params).fetchall()
+    aoi_rows = [dict(r) for r in aoi_rows]
 
     raw_params = []
     fi_raw_query = (
@@ -1797,6 +1798,7 @@ def compare_aoi_fi():
         raw_params.append(end)
     fi_raw_query += ' ORDER BY report_date DESC, id DESC'
     fi_rows = conn.execute(fi_raw_query, raw_params).fetchall()
+    fi_rows = [dict(r) for r in fi_rows]
     conn.close()
 
     return render_template(


### PR DESCRIPTION
## Summary
- Convert AOI and FI query results to lists of dictionaries for easier JSON serialization
- Verified `compare_aoi_fi.html` still iterates over dictionary entries

## Testing
- `SECRET_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a88890fdd88325bd21ad6934b848dc