### PR TITLE
Add AOI operator grading chart

### DIFF
--- a/static/js/operator_grades.js
+++ b/static/js/operator_grades.js
@@ -1,0 +1,58 @@
+// operator_grades.js
+// Render bar chart of AOI operator grades
+(function () {
+  const getJSON = id => {
+    const el = document.getElementById(id);
+    if (!el) return [];
+    try {
+      return JSON.parse(el.textContent || '[]');
+    } catch {
+      return [];
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const grades = getJSON('grade-data');
+    const labels = grades.map(g => g.operator || '');
+    const data = grades.map(g =>
+      g.coverage == null ? null : Math.round(g.coverage * 10000) / 100
+    );
+    const colors = grades.map(g => {
+      switch (g.grade) {
+        case 'A':
+          return 'green';
+        case 'B':
+          return 'blue';
+        case 'C':
+          return 'orange';
+        default:
+          return 'red';
+      }
+    });
+
+    const ctx = document.getElementById('operatorGradesChart');
+    if (ctx) {
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Detection Coverage (%)',
+              data,
+              backgroundColor: colors
+            }
+          ]
+        },
+        options: {
+          scales: {
+            y: {
+              beginAtZero: true,
+              max: 100
+            }
+          }
+        }
+      });
+    }
+  });
+})();

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -21,6 +21,7 @@
     <div style="display:flex; flex-direction:column; gap:10px; width:fit-content;">
       <button onclick="window.location='{{ url_for('analysis') }}?view=moat'">View PPM Reports</button>
       <button onclick="window.location='{{ url_for('compare_aoi_fi') }}'">Compare AOI vs Final Inspect</button>
+      <button onclick="window.location='{{ url_for('operator_grades') }}'">AOI Operator Grades</button>
     </div>
   {% else %}
     <div class="moat-stats">

--- a/templates/operator_grades.html
+++ b/templates/operator_grades.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}AOI Operator Grades{% endblock %}
+{% block head_extra %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <script id="grade-data" type="application/json">{{ grades|tojson }}</script>
+  <script src="{{ url_for('static', filename='js/operator_grades.js') }}" defer></script>
+{% endblock %}
+{% block content %}
+  <a href="{{ url_for('analysis') }}">&larr; Back to Analysis</a>
+  <h1>AOI Operator Grades</h1>
+  <canvas id="operatorGradesChart"></canvas>
+{% endblock %}

--- a/tests/test_operator_grades.py
+++ b/tests/test_operator_grades.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import math
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from run import app, init_db, get_db
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, analysis) VALUES (?,?,1)",
+        ('analyst', 'pw'),
+    )
+    conn.execute(
+        "INSERT INTO users (username, password, analysis) VALUES (?,?,0)",
+        ('noperm', 'pw'),
+    )
+    conn.commit()
+    conn.close()
+    with app.test_client() as client:
+        yield client
+
+
+def test_operator_grades_requires_login(client):
+    resp = client.get('/analysis/operator-grades', follow_redirects=False)
+    assert resp.status_code == 302
+    assert '/login' in resp.headers['Location']
+
+
+def test_operator_grades_requires_permission(client):
+    with client.session_transaction() as sess:
+        sess['user'] = 'noperm'
+    resp = client.get('/analysis/operator-grades', follow_redirects=False)
+    assert resp.status_code == 302
+    assert '/analysis' in resp.headers['Location']
+
+
+def test_operator_grades_json(client):
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ('2024-01-01', '1st', 'Jim', 'Cust', 'Asm1', 'R1', 'J1', 100, 2, ''),
+    )
+    conn.execute(
+        "INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ('2024-01-02', '1st', 'Jane', 'Cust', 'Asm2', 'R1', 'J2', 100, 5, ''),
+    )
+    conn.execute(
+        "INSERT INTO fi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ('2024-01-03', '1st', 'Sam', 'Cust', 'Asm1', 'R1', 'J1', 100, 6, ''),
+    )
+    conn.execute(
+        "INSERT INTO fi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ('2024-01-04', '1st', 'Sue', 'Cust', 'Asm2', 'R1', 'J2', 100, 1, ''),
+    )
+    conn.commit()
+    conn.close()
+
+    with client.session_transaction() as sess:
+        sess['user'] = 'analyst'
+    resp = client.get('/analysis/operator-grades?format=json')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'grades' in data
+    grades = {g['operator']: g for g in data['grades']}
+    assert math.isclose(grades['Jim']['coverage'], 0.25)
+    assert grades['Jim']['grade'] == 'D'
+    assert math.isclose(grades['Jane']['coverage'], 5 / 6)
+    assert grades['Jane']['grade'] == 'A'


### PR DESCRIPTION
## Summary
- Compute AOI operator defect coverage by joining AOI and Final Inspect data.
- Add Operator Grades page with Chart.js bar chart and navigation button.
- Test JSON endpoint for operator grades and permission handling.

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88a0c4e4c83258bf31c1c7c94141a