### PR TITLE
Show operator grades on AOI vs Final Inspect comparison

### DIFF
--- a/static/js/aoi_fi_compare.js
+++ b/static/js/aoi_fi_compare.js
@@ -25,6 +25,11 @@
 
     const ctx = document.getElementById('yieldOverlayChart');
     if (ctx) {
+      const aoiVals = dates.map(d => aoiMap[d]).filter(v => v != null);
+      const fiVals = dates.map(d => fiMap[d]).filter(v => v != null);
+      const allVals = aoiVals.concat(fiVals);
+      const minVal = allVals.length ? Math.min(...allVals) : 0.8;
+      const yMin = minVal < 0.8 ? minVal : 0.8;
       new Chart(ctx, {
         type: 'line',
         data: {
@@ -47,8 +52,8 @@
         options: {
           scales: {
             y: {
-              suggestedMin: 0,
-              suggestedMax: 1
+              min: yMin,
+              max: 1
             }
           }
         }

--- a/templates/compare_aoi_fi.html
+++ b/templates/compare_aoi_fi.html
@@ -6,7 +6,9 @@
   <script id="fi-series" type="application/json">{{ fi_series|tojson }}</script>
   <script id="aoi-data" type="application/json">{{ aoi_rows|tojson }}</script>
   <script id="fi-data" type="application/json">{{ fi_rows|tojson }}</script>
+  <script id="grade-data" type="application/json">{{ grades|tojson }}</script>
   <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/operator_grades.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_fi_compare.js') }}" defer></script>
 {% endblock %}
 {% block content %}
@@ -17,6 +19,9 @@
     <label>End: <input type="date" name="end" value="{{ end or '' }}"></label>
     <button type="submit">Apply</button>
   </form>
+  <h2>AOI Operator Grades</h2>
+  <canvas id="operatorGradesChart"></canvas>
+  <h2>Yield Comparison</h2>
   <canvas id="yieldOverlayChart"></canvas>
   <div class="comparison-panels" style="display:flex; gap:20px; flex-wrap:wrap; margin-top:20px;">
     <details class="panel" style="flex:1;" open>

--- a/tests/test_aoi_fi_compare.py
+++ b/tests/test_aoi_fi_compare.py
@@ -47,6 +47,7 @@ def test_compare_page_renders(client):
     resp = client.get('/analysis/compare')
     assert resp.status_code == 200
     assert b'yieldOverlayChart' in resp.data
+    assert b'operatorGradesChart' in resp.data
 
 
 def test_compare_jobs_json(client):


### PR DESCRIPTION
## Summary
- Display AOI operator grades above the AOI vs Final Inspect yield comparison
- Scale yield comparison Y-axis to 80–100% unless data dips lower
- Test presence of operator grades chart on the comparison page

## Testing
- `SECRET_KEY=testsecret pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88e4b98a883259fd1e3a483853342