### PR TITLE
Center and limit chart width with container wrapper

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -224,6 +224,11 @@ table thead th {
   color: var(--color-black);
 }
 
+.chart-container {
+  max-width: 600px;
+  margin: auto;
+}
+
 /* Floating report button */
 #report-button {
   position: fixed;

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -344,7 +344,9 @@
         <div id="reports-tab" class="tab-content">
           <div class="report-section" id="daily-report">
             <h2>Daily Report</h2>
-            <canvas id="daily-report-canvas" height="200" style="display:none"></canvas>
+            <div class="chart-container">
+              <canvas id="daily-report-canvas" height="200" style="display:none"></canvas>
+            </div>
             <table id="daily-report-table" style="display:none"></table>
             <label>Margin:
               <select id="daily-margin">
@@ -365,7 +367,9 @@
           </div>
           <div class="report-section" id="weekly-report">
             <h2>Weekly Report</h2>
-            <canvas id="weekly-report-canvas" height="200" style="display:none"></canvas>
+            <div class="chart-container">
+              <canvas id="weekly-report-canvas" height="200" style="display:none"></canvas>
+            </div>
             <table id="weekly-report-table" style="display:none"></table>
             <label>Margin:
               <select id="weekly-margin">
@@ -386,7 +390,9 @@
           </div>
           <div class="report-section" id="monthly-report">
             <h2>Monthly Report</h2>
-            <canvas id="monthly-report-canvas" height="200" style="display:none"></canvas>
+            <div class="chart-container">
+              <canvas id="monthly-report-canvas" height="200" style="display:none"></canvas>
+            </div>
             <table id="monthly-report-table" style="display:none"></table>
             <label>Margin:
               <select id="monthly-margin">
@@ -407,7 +413,9 @@
           </div>
           <div class="report-section" id="yearly-report">
             <h2>Yearly Report</h2>
-            <canvas id="yearly-report-canvas" height="200" style="display:none"></canvas>
+            <div class="chart-container">
+              <canvas id="yearly-report-canvas" height="200" style="display:none"></canvas>
+            </div>
             <table id="yearly-report-table" style="display:none"></table>
             <label>Margin:
               <select id="yearly-margin">
@@ -483,7 +491,9 @@
       <div class="modal-content">
         <span id="close-chart-modal" class="close">&times;</span>
         <h2>Control Chart - Avg FalseCall Rate</h2>
-        <canvas id="chart-canvas" height="200"></canvas>
+        <div class="chart-container">
+          <canvas id="chart-canvas" height="200"></canvas>
+        </div>
         <p id="fc-chart-summary" class="chart-summary"></p>
         <table id="fc-data-table"></table>
         <label>Margin:
@@ -502,7 +512,9 @@
       <div class="modal-content">
         <span id="close-chart-ng-modal" class="close">&times;</span>
         <h2>Control Chart - Avg NG Rate</h2>
-        <canvas id="chart-ng-canvas" height="200"></canvas>
+        <div class="chart-container">
+          <canvas id="chart-ng-canvas" height="200"></canvas>
+        </div>
         <p id="ng-chart-summary" class="chart-summary"></p>
         <table id="ng-data-table"></table>
         <label>Margin:
@@ -520,7 +532,9 @@
       <div class="modal-content">
         <span id="close-chart-stddev-modal" class="close">&times;</span>
         <h2>Std Dev - Avg FC per Assembly</h2>
-        <canvas id="chart-stddev-canvas" height="200"></canvas>
+        <div class="chart-container">
+          <canvas id="chart-stddev-canvas" height="200"></canvas>
+        </div>
         <p id="stddev-chart-summary" class="chart-summary"></p>
         <table id="std-data-table"></table>
         <label>Margin:
@@ -538,7 +552,9 @@
       <div class="modal-content">
         <span id="close-chart-ng-stddev-modal" class="close">&times;</span>
         <h2>Std Dev - Avg NG per Assembly</h2>
-        <canvas id="chart-ng-stddev-canvas" height="200"></canvas>
+        <div class="chart-container">
+          <canvas id="chart-ng-stddev-canvas" height="200"></canvas>
+        </div>
         <p id="ng-stddev-chart-summary" class="chart-summary"></p>
         <table id="ng-std-data-table"></table>
         <label>Margin:

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -141,16 +141,26 @@
             </form>
           </div>
           <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="operatorsChart"></canvas>
+          <div class="chart-container">
+            <canvas id="operatorsChart"></canvas>
+          </div>
           <h2>Shift Totals <button class="expand-chart" data-chart="shift" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="shiftChart"></canvas>
+          <div class="chart-container">
+            <canvas id="shiftChart"></canvas>
+          </div>
           <h2>Operator Reject Rates per Customer <button class="expand-chart" data-chart="customer" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="customerChart"></canvas>
+          <div class="chart-container">
+            <canvas id="customerChart"></canvas>
+          </div>
           <h2>Std Dev of Reject Rates per Customer <button class="expand-chart" data-chart="customer-std" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="customerStdChart"></canvas>
+          <div class="chart-container">
+            <canvas id="customerStdChart"></canvas>
+          </div>
           <p id="customerStdChartSummary" class="chart-summary"></p>
           <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="yieldChart"></canvas>
+          <div class="chart-container">
+            <canvas id="yieldChart"></canvas>
+          </div>
           <h2>Performance per Assembly</h2>
           <table id="assemblyTable">
             <thead>
@@ -184,10 +194,18 @@
           </nav>
           <div id="daily" class="subtab-content active">
             <h2>Daily Summary <button class="download-report" data-period="daily">Download PDF</button></h2>
-            <canvas id="daily-operators"></canvas>
-            <canvas id="daily-shift"></canvas>
-            <canvas id="daily-reject"></canvas>
-            <canvas id="daily-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="daily-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="daily-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="daily-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="daily-yield"></canvas>
+            </div>
             <table id="daily-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -197,10 +215,18 @@
           </div>
           <div id="weekly" class="subtab-content">
             <h2>Weekly Summary <button class="download-report" data-period="weekly">Download PDF</button></h2>
-            <canvas id="weekly-operators"></canvas>
-            <canvas id="weekly-shift"></canvas>
-            <canvas id="weekly-reject"></canvas>
-            <canvas id="weekly-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="weekly-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="weekly-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="weekly-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="weekly-yield"></canvas>
+            </div>
             <table id="weekly-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -210,10 +236,18 @@
           </div>
           <div id="monthly" class="subtab-content">
             <h2>Monthly Summary <button class="download-report" data-period="monthly">Download PDF</button></h2>
-            <canvas id="monthly-operators"></canvas>
-            <canvas id="monthly-shift"></canvas>
-            <canvas id="monthly-reject"></canvas>
-            <canvas id="monthly-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="monthly-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="monthly-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="monthly-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="monthly-yield"></canvas>
+            </div>
             <table id="monthly-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -223,10 +257,18 @@
           </div>
           <div id="yearly" class="subtab-content">
             <h2>Yearly Summary <button class="download-report" data-period="yearly">Download PDF</button></h2>
-            <canvas id="yearly-operators"></canvas>
-            <canvas id="yearly-shift"></canvas>
-            <canvas id="yearly-reject"></canvas>
-            <canvas id="yearly-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="yearly-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="yearly-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="yearly-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="yearly-yield"></canvas>
+            </div>
             <table id="yearly-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -306,7 +348,9 @@
     <div class="modal-content">
       <span id="close-chart-modal" class="close">&times;</span>
       <h2 id="modal-chart-title"></h2>
-      <canvas id="modal-chart" height="200"></canvas>
+      <div class="chart-container">
+        <canvas id="modal-chart" height="200"></canvas>
+      </div>
       <table id="modal-table">
         <thead></thead>
         <tbody></tbody>

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -7,5 +7,7 @@
 {% block content %}
   <a href="/">← Home</a>
   <h1>Control Chart – Average FalseCall Rate</h1>
-  <canvas id="popup-chart" height="200"></canvas>
+  <div class="chart-container">
+    <canvas id="popup-chart" height="200"></canvas>
+  </div>
 {% endblock %}

--- a/templates/compare_aoi_fi.html
+++ b/templates/compare_aoi_fi.html
@@ -20,9 +20,13 @@
     <button type="submit">Apply</button>
   </form>
   <h2>AOI Operator Grades</h2>
-  <canvas id="operatorGradesChart"></canvas>
+  <div class="chart-container">
+    <canvas id="operatorGradesChart"></canvas>
+  </div>
   <h2>Yield Comparison</h2>
-  <canvas id="yieldOverlayChart"></canvas>
+  <div class="chart-container">
+    <canvas id="yieldOverlayChart"></canvas>
+  </div>
   <div class="comparison-panels" style="display:flex; gap:20px; flex-wrap:wrap; margin-top:20px;">
     <details class="panel" style="flex:1;" open>
       <summary>AOI Reports</summary>

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -141,16 +141,26 @@
             </form>
           </div>
           <h2>Top Operators by Inspected Quantity <button class="expand-chart" data-chart="operators" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="operatorsChart"></canvas>
+          <div class="chart-container">
+            <canvas id="operatorsChart"></canvas>
+          </div>
           <h2>Shift Totals <button class="expand-chart" data-chart="shift" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="shiftChart"></canvas>
+          <div class="chart-container">
+            <canvas id="shiftChart"></canvas>
+          </div>
           <h2>Operator Reject Rates per Customer <button class="expand-chart" data-chart="customer" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="customerChart"></canvas>
+          <div class="chart-container">
+            <canvas id="customerChart"></canvas>
+          </div>
           <h2>Std Dev of Reject Rates per Customer <button class="expand-chart" data-chart="customer-std" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="customerStdChart"></canvas>
+          <div class="chart-container">
+            <canvas id="customerStdChart"></canvas>
+          </div>
           <p id="customerStdChartSummary" class="chart-summary"></p>
           <h2>Overall Yield Over Time <button class="expand-chart" data-chart="yield" aria-label="Expand chart">⤢</button></h2>
-          <canvas id="yieldChart"></canvas>
+          <div class="chart-container">
+            <canvas id="yieldChart"></canvas>
+          </div>
           <h2>Performance per Assembly</h2>
           <table id="assemblyTable">
             <thead>
@@ -184,10 +194,18 @@
           </nav>
           <div id="daily" class="subtab-content active">
             <h2>Daily Summary <button class="download-report" data-period="daily">Download PDF</button></h2>
-            <canvas id="daily-operators"></canvas>
-            <canvas id="daily-shift"></canvas>
-            <canvas id="daily-reject"></canvas>
-            <canvas id="daily-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="daily-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="daily-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="daily-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="daily-yield"></canvas>
+            </div>
             <table id="daily-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -197,10 +215,18 @@
           </div>
           <div id="weekly" class="subtab-content">
             <h2>Weekly Summary <button class="download-report" data-period="weekly">Download PDF</button></h2>
-            <canvas id="weekly-operators"></canvas>
-            <canvas id="weekly-shift"></canvas>
-            <canvas id="weekly-reject"></canvas>
-            <canvas id="weekly-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="weekly-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="weekly-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="weekly-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="weekly-yield"></canvas>
+            </div>
             <table id="weekly-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -210,10 +236,18 @@
           </div>
           <div id="monthly" class="subtab-content">
             <h2>Monthly Summary <button class="download-report" data-period="monthly">Download PDF</button></h2>
-            <canvas id="monthly-operators"></canvas>
-            <canvas id="monthly-shift"></canvas>
-            <canvas id="monthly-reject"></canvas>
-            <canvas id="monthly-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="monthly-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="monthly-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="monthly-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="monthly-yield"></canvas>
+            </div>
             <table id="monthly-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -223,10 +257,18 @@
           </div>
           <div id="yearly" class="subtab-content">
             <h2>Yearly Summary <button class="download-report" data-period="yearly">Download PDF</button></h2>
-            <canvas id="yearly-operators"></canvas>
-            <canvas id="yearly-shift"></canvas>
-            <canvas id="yearly-reject"></canvas>
-            <canvas id="yearly-yield"></canvas>
+            <div class="chart-container">
+              <canvas id="yearly-operators"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="yearly-shift"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="yearly-reject"></canvas>
+            </div>
+            <div class="chart-container">
+              <canvas id="yearly-yield"></canvas>
+            </div>
             <table id="yearly-table">
               <thead>
                 <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>Yield</th></tr>
@@ -306,7 +348,9 @@
     <div class="modal-content">
       <span id="close-chart-modal" class="close">&times;</span>
       <h2 id="modal-chart-title"></h2>
-      <canvas id="modal-chart" height="200"></canvas>
+      <div class="chart-container">
+        <canvas id="modal-chart" height="200"></canvas>
+      </div>
       <table id="modal-table">
         <thead></thead>
         <tbody></tbody>

--- a/templates/operator_grades.html
+++ b/templates/operator_grades.html
@@ -8,5 +8,7 @@
 {% block content %}
   <a href="{{ url_for('analysis') }}">&larr; Back to Analysis</a>
   <h1>AOI Operator Grades</h1>
-  <canvas id="operatorGradesChart"></canvas>
+  <div class="chart-container">
+    <canvas id="operatorGradesChart"></canvas>
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add `.chart-container` CSS to center charts and limit width
- Wrap chart canvases across templates (operator grades, comparison, analysis, AOI, final inspect, etc.) with the new container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a88fe43c9c832585dfa4989325a1cd