### PR TITLE
Handle AOI operators without FI data in grade report

### DIFF
--- a/run.py
+++ b/run.py
@@ -1817,7 +1817,7 @@ def compare_aoi_fi():
         )
         SELECT a.operator, SUM(a.aoi_rejected) AS aoi_rejected, SUM(f.fi_rejected) AS fi_rejected
         FROM a
-        JOIN f ON a.job_number = f.job_number AND a.assembly = f.assembly
+        LEFT JOIN f ON a.job_number = f.job_number AND a.assembly = f.assembly
         GROUP BY a.operator
         ORDER BY a.operator
         """
@@ -1949,7 +1949,7 @@ def operator_grades():
         )
         SELECT a.operator, SUM(a.aoi_rejected) AS aoi_rejected, SUM(f.fi_rejected) AS fi_rejected
         FROM a
-        JOIN f ON a.job_number = f.job_number AND a.assembly = f.assembly
+        LEFT JOIN f ON a.job_number = f.job_number AND a.assembly = f.assembly
         GROUP BY a.operator
         ORDER BY a.operator
         """
@@ -1974,8 +1974,13 @@ def operator_grades():
     grades = []
     for r in rows:
         a_rej = r['aoi_rejected'] or 0
-        f_rej = r['fi_rejected'] or 0
-        coverage, letter = compute_grade(a_rej, f_rej)
+        f_rej = r['fi_rejected']
+        if f_rej is None:
+            coverage = None
+            letter = None
+        else:
+            f_rej = f_rej or 0
+            coverage, letter = compute_grade(a_rej, f_rej)
         grades.append({'operator': r['operator'], 'coverage': coverage, 'grade': letter})
 
     if request.args.get('format') == 'json':

--- a/static/js/operator_grades.js
+++ b/static/js/operator_grades.js
@@ -15,9 +15,10 @@
     const grades = getJSON('grade-data');
     const labels = grades.map(g => g.operator || '');
     const data = grades.map(g =>
-      g.coverage == null ? null : Math.round(g.coverage * 10000) / 100
+      g.coverage == null ? 0 : Math.round(g.coverage * 10000) / 100
     );
     const colors = grades.map(g => {
+      if (g.grade == null) return 'gray';
       switch (g.grade) {
         case 'A':
           return 'green';

--- a/tests/test_operator_grades.py
+++ b/tests/test_operator_grades.py
@@ -52,6 +52,10 @@ def test_operator_grades_json(client):
         ('2024-01-02', '1st', 'Jane', 'Cust', 'Asm2', 'R1', 'J2', 100, 5, ''),
     )
     conn.execute(
+        "INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ('2024-01-05', '1st', 'Bob', 'Cust', 'Asm3', 'R1', 'J3', 100, 3, ''),
+    )
+    conn.execute(
         "INSERT INTO fi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
         ('2024-01-03', '1st', 'Sam', 'Cust', 'Asm1', 'R1', 'J1', 100, 6, ''),
     )
@@ -73,3 +77,5 @@ def test_operator_grades_json(client):
     assert grades['Jim']['grade'] == 'D'
     assert math.isclose(grades['Jane']['coverage'], 5 / 6)
     assert grades['Jane']['grade'] == 'A'
+    assert grades['Bob']['coverage'] is None
+    assert grades['Bob']['grade'] is None


### PR DESCRIPTION
## Summary
- Include AOI operators lacking FI data by switching to a LEFT JOIN and guarding against NULL FI values
- Show operators missing FI data in the chart with gray zero-height bars
- Add regression test for operators with no FI records

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89223b5b483258a20274417e6c8e8