### PR TITLE
Enable editing of AOI job numbers

### DIFF
--- a/run.py
+++ b/run.py
@@ -1017,6 +1017,38 @@ def delete_aoi_record(row_id):
     except Exception as e:
         return jsonify(error=str(e)), 500
 
+
+@app.route('/aoi/<int:row_id>', methods=['PATCH'])
+@login_required
+def update_aoi_record(row_id):
+    if not has_permission('aoi'):
+        return jsonify(error='Forbidden'), 403
+    data = request.get_json() or {}
+    field = data.get('field')
+    value = data.get('value', '')
+    allowed_fields = {
+        'report_date',
+        'shift',
+        'operator',
+        'customer',
+        'assembly',
+        'rev',
+        'job_number',
+        'qty_inspected',
+        'qty_rejected',
+        'additional_info',
+    }
+    if field not in allowed_fields:
+        return jsonify(error='Invalid field'), 400
+    try:
+        conn = get_db()
+        conn.execute(f'UPDATE aoi_reports SET {field} = ? WHERE id = ?', (value, row_id))
+        conn.commit()
+        conn.close()
+        return jsonify(success=True)
+    except Exception as e:
+        return jsonify(error=str(e)), 500
+
 @app.route('/final-inspect', methods=['GET', 'POST'])
 @login_required
 def final_inspect_report():

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -185,6 +185,32 @@ window.addEventListener('DOMContentLoaded', () => {
         console.error(err);
       }
     });
+
+    table.addEventListener('focusout', async e => {
+      if (!e.target.classList.contains('editable')) return;
+      const cell = e.target;
+      const row = cell.closest('tr');
+      const id = row.dataset.id;
+      const field = cell.dataset.field;
+      const value = cell.textContent.trim();
+      if (!id || !field) return;
+      try {
+        const tokenEl = document.querySelector('input[name=csrf_token]');
+        const headers = { 'Content-Type': 'application/json' };
+        if (tokenEl) headers['X-CSRFToken'] = tokenEl.value;
+        const resp = await fetch(`/${basePath}/${id}`, {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify({ field, value })
+        });
+        const data = await resp.json();
+        if (!data.success) {
+          alert(data.error || 'Update failed');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
   }
 
   // Collapsible cards

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -329,7 +329,7 @@
             <td>{{ r['customer'] }}</td>
             <td>{{ r['assembly'] }}</td>
             <td>{{ r['rev'] }}</td>
-            <td>{{ r['job_number'] }}</td>
+            <td{% if is_admin or permissions['aoi'] %} contenteditable="true" class="editable" data-field="job_number"{% endif %}>{{ r['job_number'] }}</td>
             <td>{{ r['qty_inspected'] }}</td>
             <td>{{ r['qty_rejected'] }}</td>
             <td>{{ r['additional_info'] }}</td>

--- a/tests/test_aoi_update.py
+++ b/tests/test_aoi_update.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from run import app, init_db, get_db
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    app.config['WTF_CSRF_ENABLED'] = False
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, aoi) VALUES (?,?,1)",
+        ('editor', 'pw'),
+    )
+    conn.commit()
+    conn.close()
+    with app.test_client() as client:
+        yield client
+
+
+def test_update_job_number(client):
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO aoi_reports (report_date, shift, operator, customer, assembly, rev, job_number, qty_inspected, qty_rejected, additional_info) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ('2024-01-01', '1st', 'Op1', 'Cust', 'Asm', 'R1', '', 10, 0, ''),
+    )
+    row_id = conn.execute('SELECT id FROM aoi_reports').fetchone()['id']
+    conn.commit()
+    conn.close()
+    with client.session_transaction() as sess:
+        sess['user'] = 'editor'
+    resp = client.patch(
+        f'/aoi/{row_id}',
+        json={'field': 'job_number', 'value': 'J123'},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['success']
+    conn = get_db()
+    job = conn.execute('SELECT job_number FROM aoi_reports WHERE id = ?', (row_id,)).fetchone()['job_number']
+    conn.close()
+    assert job == 'J123'


### PR DESCRIPTION
## Summary
- Allow inline editing of AOI report job numbers in the Daily Reports table
- Persist edits through a new PATCH endpoint for AOI records
- Test updating AOI job numbers without requiring CSRF in tests

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8939bf2f88325866957fc1a7c7017