### PR TITLE
Fix flex layout for Final Inspection table

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -124,7 +124,7 @@ a { color: var(--color-accent); }
 #container { display:flex; height:80vh; margin-top:20px; }
 #analysis-actions, #markings-actions, #aoi-actions, #stencil-actions { flex:1; padding:20px; overflow:auto; }
 #divider { width:4px; background:var(--color-accent); cursor:col-resize; }
-#moat-table, #markings-table, #aoi-table, #stencil-table { flex:1; padding:10px; overflow:auto; }
+#moat-table, #markings-table, #aoi-table, #stencil-table, #final-inspect-table { flex:1; padding:10px; overflow:auto; }
 table { width:100%; border-collapse:collapse; }
 th, td { border:1px solid var(--color-black); padding:8px; text-align:center; }
 table thead th {


### PR DESCRIPTION
## Summary
- Include `#final-inspect-table` in flex layout so Final Inspection pane shares width with actions panel

## Testing
- `SECRET_KEY=secret pytest`
- `python - <<'PY'
import os
os.environ['SECRET_KEY'] = 'secret'
from run import app
client = app.test_client()
with client.session_transaction() as sess: sess['user'] = 'tester'
print('status', client.get('/final-inspect').status_code)
PY` *(ensured page renders)*

------
https://chatgpt.com/codex/tasks/task_e_68adf84f2218832593d5bd08ae1438ae