### PR TITLE
Remove operator grades link from Data Analysis page

### DIFF
--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -21,7 +21,6 @@
     <div style="display:flex; flex-direction:column; gap:10px; width:fit-content;">
       <button onclick="window.location='{{ url_for('analysis') }}?view=moat'">View PPM Reports</button>
       <button onclick="window.location='{{ url_for('compare_aoi_fi') }}'">Compare AOI vs Final Inspect</button>
-      <button onclick="window.location='{{ url_for('operator_grades') }}'">AOI Operator Grades</button>
     </div>
   {% else %}
     <div class="moat-stats">

--- a/tests/test_analysis_navigation.py
+++ b/tests/test_analysis_navigation.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from run import app, init_db, get_db
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, analysis) VALUES (?,?,1)",
+        ('analyst', 'pw'),
+    )
+    conn.commit()
+    conn.close()
+    with app.test_client() as client:
+        yield client
+
+
+def test_analysis_navigation_options(client):
+    with client.session_transaction() as sess:
+        sess['user'] = 'analyst'
+    resp = client.get('/analysis')
+    assert resp.status_code == 200
+    assert b'View PPM Reports' in resp.data
+    assert b'Compare AOI vs Final Inspect' in resp.data
+    assert b'AOI Operator Grades' not in resp.data


### PR DESCRIPTION
## Summary
- Simplify Data Analysis navigation to only include PPM reports and AOI vs Final Inspect comparison
- Add regression test ensuring navigation only shows the intended options

## Testing
- `SECRET_KEY=dev pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf95756b4832585c83de30eed79fa