### PR TITLE
Add shared PPM report import and refresh utilities

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -65,6 +65,23 @@ window.addEventListener('DOMContentLoaded', () => {
     modelFilter.dispatchEvent(new Event('change'));
   }
 
+  const refreshBtn = document.getElementById('ppm-refresh-btn');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => {
+      const tokenEl = document.querySelector('input[name=csrf_token]');
+      const headers = { 'Content-Type': 'application/json' };
+      if (tokenEl) headers['X-CSRFToken'] = tokenEl.value;
+      fetch('/analysis/refresh', { method: 'POST', headers })
+        .then(r => r.json())
+        .then(data => {
+          alert(data.message);
+          if (data.message && data.message.startsWith('Imported')) {
+            window.location.reload();
+          }
+        });
+    });
+  }
+
   function setupLineSelectors(prefix) {
     const selects = [];
     const ands = [];

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -442,6 +442,9 @@
       </datalist>
       <div id="divider"></div>
       <div id="moat-table">
+        {% if is_admin or permissions['analysis'] %}
+        <button id="ppm-refresh-btn">Report Refresh</button>
+        {% endif %}
         <div id="model-filter-container">
           <label for="model-filter">Show Models</label>
           <select id="model-filter">
@@ -567,5 +570,12 @@
         <button id="download-ng-std-pdf">Download PDF</button>
       </div>
     </div>
-  {% endif %}
-{% endblock %}
+    {% endif %}
+    {% if startup_ppm_msg %}
+    <script>
+      window.addEventListener('DOMContentLoaded', function() {
+        alert({{ startup_ppm_msg|tojson }});
+      });
+    </script>
+    {% endif %}
+  {% endblock %}

--- a/tests/test_analysis_refresh.py
+++ b/tests/test_analysis_refresh.py
@@ -1,0 +1,87 @@
+import os
+import re
+import pandas as pd
+import pytest
+
+from run import app, init_db, get_db
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr('run.DATABASE', str(db_path))
+    init_db()
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO users (username, password, analysis) VALUES (?,?,1)",
+        ('tester', 'pw')
+    )
+    conn.commit()
+    conn.close()
+    # Default to a non-existent directory so startup import does nothing
+    app.config['PUBLIC_PPM_DIR'] = str(tmp_path / 'nope')
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user'] = 'tester'
+        yield client
+
+
+def _get_token(client):
+    resp = client.get('/analysis?view=moat')
+    html = resp.get_data(as_text=True)
+    return re.search(r'name="csrf_token" value="([^"]+)"', html).group(1)
+
+
+def _create_report(dirpath):
+    df = pd.DataFrame({
+        'model_name': ['M1'],
+        'total_boards': [1],
+        'total_parts_per_board': [1],
+        'total_parts': [1],
+        'ng_parts': [0],
+        'ng_ppm': [0.0],
+        'falsecall_parts': [0],
+        'falsecall_ppm': [0.0],
+    })
+    dirpath.mkdir(parents=True, exist_ok=True)
+    file_path = dirpath / 'report.xlsx'
+    df.to_excel(file_path, index=False, startrow=5, startcol=1)
+
+
+def test_refresh_imports_new_reports(client, tmp_path):
+    token = _get_token(client)
+    root = tmp_path / 'ppm'
+    _create_report(root / 'Line0' / '20230101')
+    app.config['PUBLIC_PPM_DIR'] = str(root)
+    resp = client.post('/analysis/refresh', headers={'X-CSRFToken': token})
+    data = resp.get_json()
+    assert data['message'].startswith('Imported')
+    conn = get_db()
+    count = conn.execute('SELECT COUNT(*) FROM moat').fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+def test_refresh_no_files(client, tmp_path):
+    root = tmp_path / 'ppm'
+    (root / 'Line0' / '20230101').mkdir(parents=True)
+    app.config['PUBLIC_PPM_DIR'] = str(root)
+    token = _get_token(client)
+    resp = client.post('/analysis/refresh', headers={'X-CSRFToken': token})
+    data = resp.get_json()
+    assert data['message'] == 'No new PPM reports found.'
+
+
+def test_refresh_permission_error(client, tmp_path, monkeypatch):
+    root = tmp_path / 'ppm'
+    root.mkdir()
+    app.config['PUBLIC_PPM_DIR'] = str(root)
+    token = _get_token(client)
+
+    def fail_listdir(path):
+        raise PermissionError('denied')
+
+    monkeypatch.setattr('run.os.listdir', fail_listdir)
+    resp = client.post('/analysis/refresh', headers={'X-CSRFToken': token})
+    data = resp.get_json()
+    assert 'Permission error' in data['message']


### PR DESCRIPTION
## Summary
- Add `PUBLIC_PPM_DIR` configuration and `import_public_ppm_reports` helper to ingest PPM spreadsheets from a shared drive
- Import reports at startup, expose `/analysis/refresh` endpoint, and surface status messages in the UI
- Add UI button and JS to trigger refresh and alert results
- Add unit tests covering refresh scenarios

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adfe8455d88325a1202ffe582fa128