### PR TITLE
Integrate Bootstrap and streamline styles

### DIFF
--- a/static/css/bootstrap_overrides.css
+++ b/static/css/bootstrap_overrides.css
@@ -1,0 +1,25 @@
+:root {
+  --bs-body-bg: var(--color-white);
+  --bs-body-color: var(--color-black);
+  --bs-primary: var(--color-accent);
+}
+
+.navbar {
+  background-color: var(--color-accent);
+}
+.navbar .nav-link,
+.navbar .navbar-text {
+  color: var(--color-white);
+}
+.navbar .nav-link:hover {
+  color: var(--color-white);
+}
+
+.widget-card {
+  cursor: pointer;
+  transition: background-color 0.3s, color 0.3s;
+}
+.widget-card:hover {
+  background-color: var(--color-accent);
+  color: var(--color-white);
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -12,64 +12,6 @@ body {
 }
 h1, p { color: var(--color-black); }
 a { color: var(--color-accent); }
-.topbar {
-  text-align: right;
-  color: var(--color-black);
-  font-size: 0.8em;
-}
-.topbar a {
-  margin-left: 10px;
-  color: var(--color-accent);
-}
-.topbar button {
-  margin-left: 10px;
-  font-size: 0.8em;
-  background: var(--color-accent);
-  color: var(--color-white);
-  border: none;
-  padding: 2px 6px;
-  cursor: pointer;
-}
-.widgets {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 20px;
-  margin-top: 20px;
-}
-
-.home-row {
-  margin-top: 20px;
-}
-
-.home-row h2 {
-  text-align: left;
-  margin: 0 0 10px 0;
-}
-
-.widget-row {
-  display: flex;
-  gap: 20px;
-  flex-wrap: wrap;
-}
-.widget {
-  border:1px solid var(--color-black);
-  border-radius:8px;
-  padding:20px;
-  text-align:center;
-  cursor:pointer;
-  transition:background 0.3s,color 0.3s;
-  background: var(--color-white);
-  flex: 1 1 200px;
-  max-width: 200px;
-  height: 150px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-.widget:hover {
-  background: var(--color-accent);
-  color: var(--color-white);
-}
 
 /* Job preview section */
 .job-previews { margin: 0 -20px 20px -20px; width: calc(100% + 40px); }
@@ -88,37 +30,6 @@ a { color: var(--color-accent); }
 }
 #show-uploads-btn { font-size: 0.9em; }
 
-/* Modal styles */
-.modal {
-  display: none;
-  position: fixed;
-  z-index: 1;
-  left: 0; top: 0;
-  width: 100%; height: 100%;
-  overflow: auto;
-  background-color: rgba(0,0,0,0.4);
-}
-.modal-content {
-  background-color: var(--color-white);
-  margin: 5% auto;
-  padding: 20px;
-  border: 1px solid var(--color-black);
-  width: 80%;       /* Make modal wider */
-  max-width: none;
-  border-radius: 8px;
-  overflow-x: auto; /* Enable horizontal scroll */
-}
-.close {
-  color: var(--color-black);
-  float: right;
-  font-size: 24px;
-  font-weight: bold;
-  cursor: pointer;
-  width: 100%;
-  text-align: end;
-  align-items: end;
-}
-.close:hover { color: var(--color-accent); }
 
 /* Analysis split-screen */
 #container { display:flex; height:80vh; margin-top:20px; }
@@ -434,14 +345,9 @@ table thead th {
     border-radius: 7px;
 }
 
-/* Chart canvas sizing inside modal */
-#chart-modal .modal-content {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-}
+/* Chart canvas sizing */
 #chart-canvas {
-  width: 100%;      /* Stretch to container width */
+  width: 100%;
   height: auto;
   min-width: 600px; /* Ensure enough width for labels */
 }
@@ -465,15 +371,6 @@ body.dark-mode span {
   color: var(--color-white);
 }
 body.dark-mode a { color: var(--color-accent); }
-body.dark-mode .topbar { color: var(--color-white); }
-body.dark-mode .topbar a { color: var(--color-accent); }
-body.dark-mode .widget {
-  border-color: var(--color-white);
-  background: var(--color-black);
-  color: var(--color-white);
-}
-body.dark-mode .widget:hover { background: var(--color-accent); color: var(--color-white); }
-body.dark-mode .widget:hover p { color: var(--color-white); }
 body.dark-mode .action-card { background: var(--color-black); border-color: var(--color-white); }
 body.dark-mode .action-card p { color: var(--color-white); }
 body.dark-mode table { border-color: var(--color-white); }

--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -255,13 +255,13 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // FC Chart modal logic
   const runBtn = document.getElementById('run-chart-btn');
-  const chartModal = document.getElementById('chart-modal');
-  const closeChart = document.getElementById('close-chart-modal');
+  const chartModalEl = document.getElementById('chart-modal');
+  const chartModal = chartModalEl ? new bootstrap.Modal(chartModalEl) : null;
   const ctx = document.getElementById('chart-canvas');
   const downloadFcBtn = document.getElementById('download-fc-pdf');
   let chartInstance;
 
-  if (runBtn && chartModal && closeChart && ctx) {
+  if (runBtn && chartModal && ctx) {
     runBtn.addEventListener('click', () => {
       const start = document.getElementById('start-date').value;
       const end = document.getElementById('end-date').value;
@@ -355,11 +355,9 @@ window.addEventListener('DOMContentLoaded', () => {
           const rangeText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
           const summary = `From ${rangeText} on ${lineText}, ${entryCount} models (${totalBoards} boards) averaged a false call rate of ${avgRate.toFixed(2)}.`;
           document.getElementById('fc-chart-summary').textContent = summary;
-          chartModal.style.display = 'block';
+          chartModal.show();
         });
     });
-    closeChart.addEventListener('click', () => { chartModal.style.display = 'none'; });
-    window.addEventListener('click', e => { if (e.target === chartModal) chartModal.style.display = 'none'; });
   }
 
   if (downloadFcBtn) {
@@ -380,13 +378,13 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // NG Chart modal logic
   const runNgBtn = document.getElementById('run-ng-chart-btn');
-  const chartNgModal = document.getElementById('chart-ng-modal');
-  const closeNgChart = document.getElementById('close-chart-ng-modal');
+  const chartNgModalEl = document.getElementById('chart-ng-modal');
+  const chartNgModal = chartNgModalEl ? new bootstrap.Modal(chartNgModalEl) : null;
   const ngCtx = document.getElementById('chart-ng-canvas');
   const downloadNgBtn = document.getElementById('download-ng-pdf');
   let ngChartInstance;
 
-  if (runNgBtn && chartNgModal && closeNgChart && ngCtx) {
+  if (runNgBtn && chartNgModal && ngCtx) {
     runNgBtn.addEventListener('click', () => {
       const start = document.getElementById('ng-start-date').value;
       const end = document.getElementById('ng-end-date').value;
@@ -480,21 +478,19 @@ window.addEventListener('DOMContentLoaded', () => {
           const rangeText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
           const summary = `From ${rangeText} on ${lineText}, ${entryCount} models (${totalBoards} boards) averaged an NG rate of ${avgRate.toFixed(3)}.`;
           document.getElementById('ng-chart-summary').textContent = summary;
-          chartNgModal.style.display = 'block';
+          chartNgModal.show();
         });
     });
-    closeNgChart.addEventListener('click', () => { chartNgModal.style.display = 'none'; });
-    window.addEventListener('click', e => { if (e.target === chartNgModal) chartNgModal.style.display = 'none'; });
   }
 
   // Std Dev Chart modal logic
   const runStdBtn = document.getElementById('run-std-chart-btn');
-  const chartStdModal = document.getElementById('chart-stddev-modal');
-  const closeStdChart = document.getElementById('close-chart-stddev-modal');
+  const chartStdModalEl = document.getElementById('chart-stddev-modal');
+  const chartStdModal = chartStdModalEl ? new bootstrap.Modal(chartStdModalEl) : null;
   const stdCtx = document.getElementById('chart-stddev-canvas');
   const downloadStdBtn = document.getElementById('download-std-pdf');
   let stdChartInstance;
-  if (runStdBtn && chartStdModal && closeStdChart && stdCtx) {
+  if (runStdBtn && chartStdModal && stdCtx) {
     runStdBtn.addEventListener('click', () => {
       const start = document.getElementById('std-start-date').value;
       const end = document.getElementById('std-end-date').value;
@@ -513,7 +509,7 @@ window.addEventListener('DOMContentLoaded', () => {
           if (!rates.length) {
             stdChartInstance = new Chart(stdCtx, { type: 'bar', data: { labels: [], datasets: [] } });
             document.getElementById('stddev-chart-summary').textContent = 'No data.';
-            chartStdModal.style.display = 'block';
+            chartStdModal.show();
             return;
           }
           const mean = data.mean;
@@ -532,20 +528,18 @@ window.addEventListener('DOMContentLoaded', () => {
           }
           const rangeText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
           document.getElementById('stddev-chart-summary').textContent = `From ${rangeText} on ${lineText}, Avg FC rate ${mean.toFixed(2)} with std dev ${stdev.toFixed(2)}.`;
-          chartStdModal.style.display = 'block';
+          chartStdModal.show();
         });
     });
-    closeStdChart.addEventListener('click', () => { chartStdModal.style.display = 'none'; });
-    window.addEventListener('click', e => { if (e.target === chartStdModal) chartStdModal.style.display = 'none'; });
   }
 
   const runNgStdBtn = document.getElementById('run-ng-std-chart-btn');
-  const chartNgStdModal = document.getElementById('chart-ng-stddev-modal');
-  const closeNgStdChart = document.getElementById('close-chart-ng-stddev-modal');
+  const chartNgStdModalEl = document.getElementById('chart-ng-stddev-modal');
+  const chartNgStdModal = chartNgStdModalEl ? new bootstrap.Modal(chartNgStdModalEl) : null;
   const ngStdCtx = document.getElementById('chart-ng-stddev-canvas');
   const downloadNgStdBtn = document.getElementById('download-ng-std-pdf');
   let ngStdChartInstance;
-  if (runNgStdBtn && chartNgStdModal && closeNgStdChart && ngStdCtx) {
+  if (runNgStdBtn && chartNgStdModal && ngStdCtx) {
     runNgStdBtn.addEventListener('click', () => {
       const start = document.getElementById('ng-std-start-date').value;
       const end = document.getElementById('ng-std-end-date').value;
@@ -564,7 +558,7 @@ window.addEventListener('DOMContentLoaded', () => {
           if (!rates.length) {
             ngStdChartInstance = new Chart(ngStdCtx, { type: 'bar', data: { labels: [], datasets: [] } });
             document.getElementById('ng-stddev-chart-summary').textContent = 'No data.';
-            chartNgStdModal.style.display = 'block';
+            chartNgStdModal.show();
             return;
           }
           const mean = data.mean;
@@ -588,11 +582,9 @@ window.addEventListener('DOMContentLoaded', () => {
           }
           const rangeText = start && end ? `${start} to ${end}` : start ? `From ${start}` : end ? `Up to ${end}` : 'All dates';
           document.getElementById('ng-stddev-chart-summary').textContent = `From ${rangeText} on ${lineText}, Avg NG rate ${mean.toFixed(3)} with std dev ${stdev.toFixed(3)}.`;
-          chartNgStdModal.style.display = 'block';
+          chartNgStdModal.show();
         });
     });
-    closeNgStdChart.addEventListener('click', () => { chartNgStdModal.style.display = 'none'; });
-    window.addEventListener('click', e => { if (e.target === chartNgStdModal) chartNgStdModal.style.display = 'none'; });
   }
 
   if (downloadStdBtn) {
@@ -645,12 +637,12 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // Uploads modal logic (unchanged)
   const uploadsBtn = document.getElementById('show-uploads-btn');
-  const uploadsModal = document.getElementById('uploads-modal');
-  const closeUploads = document.getElementById('close-uploads-modal');
+  const uploadsModalEl = document.getElementById('uploads-modal');
+  const uploadsModal = uploadsModalEl ? new bootstrap.Modal(uploadsModalEl) : null;
   const uploadsList = document.getElementById('uploads-list');
-  if (uploadsBtn && uploadsModal && closeUploads && uploadsList) {
+  if (uploadsBtn && uploadsModal && uploadsList) {
     uploadsBtn.onclick = () => {
-      uploadsModal.style.display = 'block';
+      uploadsModal.show();
       uploadsList.innerHTML = '<li>Loading...</li>';
       fetch('/uploads')
         .then(res => res.json())
@@ -681,8 +673,6 @@ window.addEventListener('DOMContentLoaded', () => {
           });
         });
     };
-    closeUploads.onclick = () => { uploadsModal.style.display = 'none'; };
-    window.addEventListener('click', e => { if (e.target === uploadsModal) uploadsModal.style.display = 'none'; });
   }
 
   // Report sections (Daily, Weekly, Monthly, Yearly)

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -224,8 +224,8 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   // Expand chart modal
-  const chartModal = document.getElementById('chart-modal');
-  const closeChart = document.getElementById('close-chart-modal');
+  const chartModalEl = document.getElementById('chart-modal');
+  const chartModal = chartModalEl ? new bootstrap.Modal(chartModalEl) : null;
   const modalTitle = document.getElementById('modal-chart-title');
   const modalCanvas = document.getElementById('modal-chart');
   const modalHead = document.querySelector('#modal-table thead');
@@ -238,11 +238,8 @@ window.addEventListener('DOMContentLoaded', () => {
     modalChart = new Chart(modalCanvas, config);
     modalHead.innerHTML = '<tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr>';
     modalBody.innerHTML = rows.map(r => '<tr>' + r.map(c => `<td>${c}</td>`).join('') + '</tr>').join('');
-    chartModal.style.display = 'block';
+    chartModal.show();
   }
-
-  closeChart?.addEventListener('click', () => { chartModal.style.display = 'none'; });
-  window.addEventListener('click', e => { if (e.target === chartModal) chartModal.style.display = 'none'; });
 
   document.querySelectorAll('.expand-chart').forEach(btn => {
     btn.addEventListener('click', () => {

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -480,94 +480,124 @@
     </div>
 
     <!-- Uploads Modal -->
-    <div id="uploads-modal" class="modal">
-      <div class="modal-content">
-        <span id="close-uploads-modal" class="close">&times;</span>
-        <h2>Uploaded Files</h2>
-        <ul id="uploads-list"></ul>
+    <div class="modal fade" id="uploads-modal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Uploaded Files</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <ul id="uploads-list"></ul>
+          </div>
+        </div>
       </div>
     </div>
 
     <!-- Chart Modal -->
-    <div id="chart-modal" class="modal">
-      <div class="modal-content">
-        <span id="close-chart-modal" class="close">&times;</span>
-        <h2>Control Chart - Avg FalseCall Rate</h2>
-        <div class="chart-container">
-          <canvas id="chart-canvas" height="200"></canvas>
+    <div class="modal fade" id="chart-modal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Control Chart - Avg FalseCall Rate</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="chart-container">
+              <canvas id="chart-canvas" height="200"></canvas>
+            </div>
+            <p id="fc-chart-summary" class="chart-summary"></p>
+            <table id="fc-data-table"></table>
+            <label>Margin:
+              <select id="fc-margin">
+                <option value="0.25">0.25"</option>
+                <option value="0.5" selected>0.5"</option>
+                <option value="0.75">0.75"</option>
+                <option value="1">1"</option>
+              </select>
+            </label>
+            <button id="download-fc-pdf">Download PDF</button>
+          </div>
         </div>
-        <p id="fc-chart-summary" class="chart-summary"></p>
-        <table id="fc-data-table"></table>
-        <label>Margin:
-          <select id="fc-margin">
-            <option value="0.25">0.25"</option>
-            <option value="0.5" selected>0.5"</option>
-            <option value="0.75">0.75"</option>
-            <option value="1">1"</option>
-          </select>
-        </label>
-        <button id="download-fc-pdf">Download PDF</button>
       </div>
     </div>
 
-    <div id="chart-ng-modal" class="modal">
-      <div class="modal-content">
-        <span id="close-chart-ng-modal" class="close">&times;</span>
-        <h2>Control Chart - Avg NG Rate</h2>
-        <div class="chart-container">
-          <canvas id="chart-ng-canvas" height="200"></canvas>
+    <div class="modal fade" id="chart-ng-modal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Control Chart - Avg NG Rate</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="chart-container">
+              <canvas id="chart-ng-canvas" height="200"></canvas>
+            </div>
+            <p id="ng-chart-summary" class="chart-summary"></p>
+            <table id="ng-data-table"></table>
+            <label>Margin:
+              <select id="ng-margin">
+                <option value="0.25">0.25"</option>
+                <option value="0.5" selected>0.5"</option>
+                <option value="0.75">0.75"</option>
+                <option value="1">1"</option>
+              </select>
+            </label>
+            <button id="download-ng-pdf">Download PDF</button>
+          </div>
         </div>
-        <p id="ng-chart-summary" class="chart-summary"></p>
-        <table id="ng-data-table"></table>
-        <label>Margin:
-          <select id="ng-margin">
-            <option value="0.25">0.25"</option>
-            <option value="0.5" selected>0.5"</option>
-            <option value="0.75">0.75"</option>
-            <option value="1">1"</option>
-          </select>
-        </label>
-        <button id="download-ng-pdf">Download PDF</button>
       </div>
     </div>
-    <div id="chart-stddev-modal" class="modal">
-      <div class="modal-content">
-        <span id="close-chart-stddev-modal" class="close">&times;</span>
-        <h2>Std Dev - Avg FC per Assembly</h2>
-        <div class="chart-container">
-          <canvas id="chart-stddev-canvas" height="200"></canvas>
+    <div class="modal fade" id="chart-stddev-modal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Std Dev - Avg FC per Assembly</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="chart-container">
+              <canvas id="chart-stddev-canvas" height="200"></canvas>
+            </div>
+            <p id="stddev-chart-summary" class="chart-summary"></p>
+            <table id="std-data-table"></table>
+            <label>Margin:
+              <select id="std-margin">
+                <option value="0.25">0.25"</option>
+                <option value="0.5" selected>0.5"</option>
+                <option value="0.75">0.75"</option>
+                <option value="1">1"</option>
+              </select>
+            </label>
+            <button id="download-std-pdf">Download PDF</button>
+          </div>
         </div>
-        <p id="stddev-chart-summary" class="chart-summary"></p>
-        <table id="std-data-table"></table>
-        <label>Margin:
-          <select id="std-margin">
-            <option value="0.25">0.25"</option>
-            <option value="0.5" selected>0.5"</option>
-            <option value="0.75">0.75"</option>
-            <option value="1">1"</option>
-          </select>
-        </label>
-        <button id="download-std-pdf">Download PDF</button>
       </div>
     </div>
-    <div id="chart-ng-stddev-modal" class="modal">
-      <div class="modal-content">
-        <span id="close-chart-ng-stddev-modal" class="close">&times;</span>
-        <h2>Std Dev - Avg NG per Assembly</h2>
-        <div class="chart-container">
-          <canvas id="chart-ng-stddev-canvas" height="200"></canvas>
+    <div class="modal fade" id="chart-ng-stddev-modal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Std Dev - Avg NG per Assembly</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="chart-container">
+              <canvas id="chart-ng-stddev-canvas" height="200"></canvas>
+            </div>
+            <p id="ng-stddev-chart-summary" class="chart-summary"></p>
+            <table id="ng-std-data-table"></table>
+            <label>Margin:
+              <select id="ng-std-margin">
+                <option value="0.25">0.25"</option>
+                <option value="0.5" selected>0.5"</option>
+                <option value="0.75">0.75"</option>
+                <option value="1">1"</option>
+              </select>
+            </label>
+            <button id="download-ng-std-pdf">Download PDF</button>
+          </div>
         </div>
-        <p id="ng-stddev-chart-summary" class="chart-summary"></p>
-        <table id="ng-std-data-table"></table>
-        <label>Margin:
-          <select id="ng-std-margin">
-            <option value="0.25">0.25"</option>
-            <option value="0.5" selected>0.5"</option>
-            <option value="0.75">0.75"</option>
-            <option value="1">1"</option>
-          </select>
-        </label>
-        <button id="download-ng-std-pdf">Download PDF</button>
       </div>
     </div>
     {% endif %}

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -344,17 +344,23 @@
   </div>
 
   <!-- Chart Modal -->
-  <div id="chart-modal" class="modal">
-    <div class="modal-content">
-      <span id="close-chart-modal" class="close">&times;</span>
-      <h2 id="modal-chart-title"></h2>
-      <div class="chart-container">
-        <canvas id="modal-chart" height="200"></canvas>
+  <div class="modal fade" id="chart-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modal-chart-title"></h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="chart-container">
+            <canvas id="modal-chart" height="200"></canvas>
+          </div>
+          <table id="modal-table">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </div>
-      <table id="modal-table">
-        <thead></thead>
-        <tbody></tbody>
-      </table>
     </div>
   </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>{% block title %}SPCApp{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/style.css">
+  <link rel="stylesheet" href="/static/css/bootstrap_overrides.css">
   <link rel="icon" type="image/png" href="/static/images/company-logo.png">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
   <script src="/static/js/theme.js" defer></script>
   <script src="/static/js/editable.js" defer></script>
   <script src="/static/js/sql_popup.js" defer></script>
@@ -15,15 +18,19 @@
 </head>
 <body data-admin="{{ 'true' if is_admin else 'false' }}" data-base-path="{{ report_base|default('') }}">
   {% if current_user %}
-  <div class="topbar">
-    <span class="user-label">user:{{ current_user }}</span>
-    <a href="{{ url_for('docs') }}">Docs</a>
-    <a href="{{ url_for('logout') }}">Logout</a>
-    <button id="theme-toggle" type="button">Dark Mode</button>
-    {% if is_admin %}
-      <a href="{{ url_for('settings') }}">Settings</a>
-    {% endif %}
-  </div>
+  <nav class="navbar navbar-expand navbar-dark bg-primary mb-3">
+    <div class="container-fluid">
+      <div class="navbar-nav ms-auto align-items-center">
+        <span class="navbar-text text-light me-2">user:{{ current_user }}</span>
+        <a class="nav-link" href="{{ url_for('docs') }}">Docs</a>
+        <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+        <button id="theme-toggle" type="button" class="btn btn-light btn-sm ms-2">Dark Mode</button>
+        {% if is_admin %}
+        <a class="nav-link" href="{{ url_for('settings') }}">Settings</a>
+        {% endif %}
+      </div>
+    </div>
+  </nav>
   {% endif %}
   {% with messages = get_flashed_messages() %}
     {% if messages %}

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -344,17 +344,23 @@
   </div>
 
   <!-- Chart Modal -->
-  <div id="chart-modal" class="modal">
-    <div class="modal-content">
-      <span id="close-chart-modal" class="close">&times;</span>
-      <h2 id="modal-chart-title"></h2>
-      <div class="chart-container">
-        <canvas id="modal-chart" height="200"></canvas>
+  <div class="modal fade" id="chart-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modal-chart-title"></h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="chart-container">
+            <canvas id="modal-chart" height="200"></canvas>
+          </div>
+          <table id="modal-table">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </div>
-      <table id="modal-table">
-        <thead></thead>
-        <tbody></tbody>
-      </table>
     </div>
   </div>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -39,58 +39,80 @@
 
   {% if is_admin or permissions.get('analysis') or permissions.get('aoi') %}
   <div id="analysis-tab" class="tab-content active">
-    <div class="home-row">
-      <div class="widget-row">
-        {% if is_admin or permissions.get('analysis') %}
-        <div class="widget" onclick="location.href='/analysis'">
-          <h2>Data Analysis</h2>
-          <p>Upload And Data Mine Reports From SPC</p>
+    <div class="row g-3">
+      {% if is_admin or permissions.get('analysis') %}
+      <div class="col-md-3">
+        <div class="card widget-card text-center h-100" onclick="location.href='/analysis'">
+          <div class="card-body">
+            <h5 class="card-title">Data Analysis</h5>
+            <p class="card-text">Upload And Data Mine Reports From SPC</p>
+          </div>
         </div>
-        {% endif %}
-        {% if is_admin or permissions.get('aoi') %}
-        <div class="widget" onclick="location.href='/aoi'">
-          <h2>AOI Daily Report</h2>
-          <p>View and Upload AOI Reports With Data Insights.</p>
-        </div>
-        <div class="widget" onclick="location.href='/final-inspect'">
-          <h2>Final Inspect Daily Report</h2>
-          <p>View and Upload Final Inspection Reports With Data Insights.</p>
-        </div>
-        {% endif %}
       </div>
+      {% endif %}
+      {% if is_admin or permissions.get('aoi') %}
+      <div class="col-md-3">
+        <div class="card widget-card text-center h-100" onclick="location.href='/aoi'">
+          <div class="card-body">
+            <h5 class="card-title">AOI Daily Report</h5>
+            <p class="card-text">View and Upload AOI Reports With Data Insights.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card widget-card text-center h-100" onclick="location.href='/final-inspect'">
+          <div class="card-body">
+            <h5 class="card-title">Final Inspect Daily Report</h5>
+            <p class="card-text">View and Upload Final Inspection Reports With Data Insights.</p>
+          </div>
+        </div>
+      </div>
+      {% endif %}
     </div>
   </div>
   {% endif %}
 
   <div id="tools-tab" class="tab-content{% if not (is_admin or permissions.get('analysis') or permissions.get('aoi')) %} active{% endif %}">
-    <div class="home-row">
-      <div class="widget-row">
-        <div class="widget" onclick="location.href='/rework'">
-          <h2>Rework</h2>
-          <p>Stencil and part lookup tools</p>
+    <div class="row g-3">
+      <div class="col-md-3">
+        <div class="card widget-card text-center h-100" onclick="location.href='/rework'">
+          <div class="card-body">
+            <h5 class="card-title">Rework</h5>
+            <p class="card-text">Stencil and part lookup tools</p>
+          </div>
         </div>
-        {% if is_admin or permissions.get('part_markings') %}
-        <div class="widget" onclick="location.href='/part-markings'">
-          <h2>Verified Part Markings</h2>
-          <p>Lookup Part Numbers To Find Their Verified Part Markings</p>
-        </div>
-        {% endif %}
       </div>
+      {% if is_admin or permissions.get('part_markings') %}
+      <div class="col-md-3">
+        <div class="card widget-card text-center h-100" onclick="location.href='/part-markings'">
+          <div class="card-body">
+            <h5 class="card-title">Verified Part Markings</h5>
+            <p class="card-text">Lookup Part Numbers To Find Their Verified Part Markings</p>
+          </div>
+        </div>
+      </div>
+      {% endif %}
     </div>
   </div>
 
   <div id="production-tab" class="tab-content">
-    <div class="home-row">
-      <div class="widget-row">
-        {% if is_admin or permissions.get('dashboard') %}
-        <div class="widget" onclick="location.href='#'">
-          <h2>SPC Dashboard</h2>
-          <p>Statistical Controls (<i>in progress</i>)</p>
+    <div class="row g-3">
+      {% if is_admin or permissions.get('dashboard') %}
+      <div class="col-md-3">
+        <div class="card widget-card text-center h-100" onclick="location.href='#'">
+          <div class="card-body">
+            <h5 class="card-title">SPC Dashboard</h5>
+            <p class="card-text">Statistical Controls (<i>in progress</i>)</p>
+          </div>
         </div>
-        {% endif %}
-        <div class="widget" onclick="location.href='/jobs'">
-          <h2>Jobs</h2>
-          <p>Manage Floor Jobs (<i>in progress</i>)</p>
+      </div>
+      {% endif %}
+      <div class="col-md-3">
+        <div class="card widget-card text-center h-100" onclick="location.href='/jobs'">
+          <div class="card-body">
+            <h5 class="card-title">Jobs</h5>
+            <p class="card-text">Manage Floor Jobs (<i>in progress</i>)</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Load Bootstrap CSS/JS and replace custom top bar with a Bootstrap navbar
- Swap home page widgets and modals for Bootstrap cards and modals, removing redundant CSS
- Add bootstrap_overrides.css to keep existing color palette

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d0993108325b5ce7b4f9cdf3e3b