### PR TITLE
Add global navigation and accessible layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -13,6 +13,13 @@ body {
 h1, p { color: var(--color-black); }
 a { color: var(--color-accent); }
 
+/* Accessible focus outlines for navigation */
+.navbar-nav .nav-link:focus,
+.dropdown-menu .dropdown-item:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 /* Job preview section */
 .job-previews { margin: 0 -20px 20px -20px; width: calc(100% + 40px); }
 .job-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; width: 100%; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,16 +18,57 @@
 </head>
 <body data-admin="{{ 'true' if is_admin else 'false' }}" data-base-path="{{ report_base|default('') }}">
   {% if current_user %}
-  <nav class="navbar navbar-expand navbar-dark bg-primary mb-3">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-3" aria-label="Main navigation">
     <div class="container-fluid">
-      <div class="navbar-nav ms-auto align-items-center">
-        <span class="navbar-text text-light me-2">user:{{ current_user }}</span>
-        <a class="nav-link" href="{{ url_for('docs') }}">Docs</a>
-        <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
-        <button id="theme-toggle" type="button" class="btn btn-light btn-sm ms-2">Dark Mode</button>
-        {% if is_admin %}
-        <a class="nav-link" href="{{ url_for('settings') }}">Settings</a>
-        {% endif %}
+      <a class="navbar-brand" href="{{ url_for('home') }}">SPCApp</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav me-auto">
+          <li class="nav-item">
+            <a class="nav-link{% if request.endpoint == 'home' %} active{% endif %}" href="{{ url_for('home') }}"{% if request.endpoint == 'home' %} aria-current="page"{% endif %}>Home</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle{% if request.endpoint and (request.endpoint.startswith('analysis') or request.endpoint in ['aoi_report','final_inspect_report']) %} active{% endif %}" href="#" id="analysisDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Analysis</a>
+            <ul class="dropdown-menu" aria-labelledby="analysisDropdown">
+              {% if is_admin or permissions.get('analysis') %}
+              <li><a class="dropdown-item{% if request.endpoint == 'analysis' %} active{% endif %}" href="{{ url_for('analysis') }}"{% if request.endpoint == 'analysis' %} aria-current="page"{% endif %}>Data Analysis</a></li>
+              {% endif %}
+              {% if is_admin or permissions.get('aoi') %}
+              <li><a class="dropdown-item{% if request.endpoint == 'aoi_report' %} active{% endif %}" href="{{ url_for('aoi_report') }}"{% if request.endpoint == 'aoi_report' %} aria-current="page"{% endif %}>AOI Daily Report</a></li>
+              <li><a class="dropdown-item{% if request.endpoint == 'final_inspect_report' %} active{% endif %}" href="{{ url_for('final_inspect_report') }}"{% if request.endpoint == 'final_inspect_report' %} aria-current="page"{% endif %}>Final Inspect Daily Report</a></li>
+              {% endif %}
+            </ul>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle{% if request.endpoint and (request.endpoint.startswith('rework') or request.endpoint.startswith('part_markings')) %} active{% endif %}" href="#" id="toolsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Tools</a>
+            <ul class="dropdown-menu" aria-labelledby="toolsDropdown">
+              <li><a class="dropdown-item{% if request.endpoint == 'rework' %} active{% endif %}" href="{{ url_for('rework') }}"{% if request.endpoint == 'rework' %} aria-current="page"{% endif %}>Rework</a></li>
+              {% if is_admin or permissions.get('part_markings') %}
+              <li><a class="dropdown-item{% if request.endpoint == 'part_markings' %} active{% endif %}" href="{{ url_for('part_markings') }}"{% if request.endpoint == 'part_markings' %} aria-current="page"{% endif %}>Verified Part Markings</a></li>
+              {% endif %}
+            </ul>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle{% if request.endpoint and request.endpoint.startswith('jobs') %} active{% endif %}" href="#" id="productionDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Production</a>
+            <ul class="dropdown-menu" aria-labelledby="productionDropdown">
+              {% if is_admin or permissions.get('dashboard') %}
+              <li><span class="dropdown-item disabled">SPC Dashboard</span></li>
+              {% endif %}
+              <li><a class="dropdown-item" href="/jobs">Jobs</a></li>
+            </ul>
+          </li>
+        </ul>
+        <div class="navbar-nav ms-auto align-items-center">
+          <span class="navbar-text text-light me-2">user:{{ current_user }}</span>
+          <a class="nav-link{% if request.endpoint == 'docs' %} active{% endif %}" href="{{ url_for('docs') }}"{% if request.endpoint == 'docs' %} aria-current="page"{% endif %}>Docs</a>
+          {% if is_admin %}
+          <a class="nav-link{% if request.endpoint == 'settings' %} active{% endif %}" href="{{ url_for('settings') }}"{% if request.endpoint == 'settings' %} aria-current="page"{% endif %}>Settings</a>
+          {% endif %}
+          <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          <button id="theme-toggle" type="button" class="btn btn-light btn-sm ms-2">Dark Mode</button>
+        </div>
       </div>
     </div>
   </nav>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,8 +1,5 @@
 {% extends 'base.html' %}
 {% block title %}SPCApp Home{% endblock %}
-{% block head_extra %}
-  <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
-{% endblock %}
 {% block content %}
   <div class="home-title">
     <img src="/static/images/image.png" alt="Spectra Tech Logo">
@@ -29,90 +26,79 @@
   #}
   <p>Select a section below:</p>
 
-  <nav class="tab-nav">
-    {% if is_admin or permissions.get('analysis') or permissions.get('aoi') %}
-    <button class="tab-link active" data-tab="analysis-tab" data-desc="Upload and explore reports for data insights.">Analysis</button>
-    {% endif %}
-    <button class="tab-link{% if not (is_admin or permissions.get('analysis') or permissions.get('aoi')) %} active{% endif %}" data-tab="tools-tab" data-desc="Utilities such as rework lookup and verified part markings.">Tools</button>
-    <button class="tab-link" data-tab="production-tab" data-desc="Dashboards and job management features.">Production</button>
-  </nav>
-
   {% if is_admin or permissions.get('analysis') or permissions.get('aoi') %}
-  <div id="analysis-tab" class="tab-content active">
-    <div class="row g-3">
-      {% if is_admin or permissions.get('analysis') %}
-      <div class="col-md-3">
-        <div class="card widget-card text-center h-100" onclick="location.href='/analysis'">
-          <div class="card-body">
-            <h5 class="card-title">Data Analysis</h5>
-            <p class="card-text">Upload And Data Mine Reports From SPC</p>
-          </div>
+  <h2>Analysis</h2>
+  <div class="row g-3 mb-4">
+    {% if is_admin or permissions.get('analysis') %}
+    <div class="col-md-3">
+      <div class="card widget-card text-center h-100" onclick="location.href='/analysis'" role="link" tabindex="0">
+        <div class="card-body">
+          <h5 class="card-title">Data Analysis</h5>
+          <p class="card-text">Upload And Data Mine Reports From SPC</p>
         </div>
       </div>
-      {% endif %}
-      {% if is_admin or permissions.get('aoi') %}
-      <div class="col-md-3">
-        <div class="card widget-card text-center h-100" onclick="location.href='/aoi'">
-          <div class="card-body">
-            <h5 class="card-title">AOI Daily Report</h5>
-            <p class="card-text">View and Upload AOI Reports With Data Insights.</p>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-3">
-        <div class="card widget-card text-center h-100" onclick="location.href='/final-inspect'">
-          <div class="card-body">
-            <h5 class="card-title">Final Inspect Daily Report</h5>
-            <p class="card-text">View and Upload Final Inspection Reports With Data Insights.</p>
-          </div>
-        </div>
-      </div>
-      {% endif %}
     </div>
+    {% endif %}
+    {% if is_admin or permissions.get('aoi') %}
+    <div class="col-md-3">
+      <div class="card widget-card text-center h-100" onclick="location.href='/aoi'" role="link" tabindex="0">
+        <div class="card-body">
+          <h5 class="card-title">AOI Daily Report</h5>
+          <p class="card-text">View and Upload AOI Reports With Data Insights.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card widget-card text-center h-100" onclick="location.href='/final-inspect'" role="link" tabindex="0">
+        <div class="card-body">
+          <h5 class="card-title">Final Inspect Daily Report</h5>
+          <p class="card-text">View and Upload Final Inspection Reports With Data Insights.</p>
+        </div>
+      </div>
+    </div>
+    {% endif %}
   </div>
   {% endif %}
 
-  <div id="tools-tab" class="tab-content{% if not (is_admin or permissions.get('analysis') or permissions.get('aoi')) %} active{% endif %}">
-    <div class="row g-3">
-      <div class="col-md-3">
-        <div class="card widget-card text-center h-100" onclick="location.href='/rework'">
-          <div class="card-body">
-            <h5 class="card-title">Rework</h5>
-            <p class="card-text">Stencil and part lookup tools</p>
-          </div>
+  <h2>Tools</h2>
+  <div class="row g-3 mb-4">
+    <div class="col-md-3">
+      <div class="card widget-card text-center h-100" onclick="location.href='/rework'" role="link" tabindex="0">
+        <div class="card-body">
+          <h5 class="card-title">Rework</h5>
+          <p class="card-text">Stencil and part lookup tools</p>
         </div>
       </div>
-      {% if is_admin or permissions.get('part_markings') %}
-      <div class="col-md-3">
-        <div class="card widget-card text-center h-100" onclick="location.href='/part-markings'">
-          <div class="card-body">
-            <h5 class="card-title">Verified Part Markings</h5>
-            <p class="card-text">Lookup Part Numbers To Find Their Verified Part Markings</p>
-          </div>
-        </div>
-      </div>
-      {% endif %}
     </div>
+    {% if is_admin or permissions.get('part_markings') %}
+    <div class="col-md-3">
+      <div class="card widget-card text-center h-100" onclick="location.href='/part-markings'" role="link" tabindex="0">
+        <div class="card-body">
+          <h5 class="card-title">Verified Part Markings</h5>
+          <p class="card-text">Lookup Part Numbers To Find Their Verified Part Markings</p>
+        </div>
+      </div>
+    </div>
+    {% endif %}
   </div>
 
-  <div id="production-tab" class="tab-content">
-    <div class="row g-3">
-      {% if is_admin or permissions.get('dashboard') %}
-      <div class="col-md-3">
-        <div class="card widget-card text-center h-100" onclick="location.href='#'">
-          <div class="card-body">
-            <h5 class="card-title">SPC Dashboard</h5>
-            <p class="card-text">Statistical Controls (<i>in progress</i>)</p>
-          </div>
+  <h2>Production</h2>
+  <div class="row g-3">
+    {% if is_admin or permissions.get('dashboard') %}
+    <div class="col-md-3">
+      <div class="card widget-card text-center h-100" onclick="location.href='#'" role="link" tabindex="0">
+        <div class="card-body">
+          <h5 class="card-title">SPC Dashboard</h5>
+          <p class="card-text">Statistical Controls (<i>in progress</i>)</p>
         </div>
       </div>
-      {% endif %}
-      <div class="col-md-3">
-        <div class="card widget-card text-center h-100" onclick="location.href='/jobs'">
-          <div class="card-body">
-            <h5 class="card-title">Jobs</h5>
-            <p class="card-text">Manage Floor Jobs (<i>in progress</i>)</p>
-          </div>
+    </div>
+    {% endif %}
+    <div class="col-md-3">
+      <div class="card widget-card text-center h-100" onclick="location.href='/jobs'" role="link" tabindex="0">
+        <div class="card-body">
+          <h5 class="card-title">Jobs</h5>
+          <p class="card-text">Manage Floor Jobs (<i>in progress</i>)</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add responsive top navbar with dropdown navigation for Analysis, Tools, and Production
- Replace home page tabs with simple sections linking to dedicated views
- Improve accessibility with ARIA attributes and visible focus outlines

## Testing
- `SECRET_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae3f3e1834832592ddb00236b6bc94