### PR TITLE
feat: standardize form controls

### DIFF
--- a/static/js/validation.js
+++ b/static/js/validation.js
@@ -1,0 +1,15 @@
+(() => {
+  'use strict';
+  window.addEventListener('DOMContentLoaded', () => {
+    const forms = document.querySelectorAll('.needs-validation');
+    Array.from(forms).forEach(form => {
+      form.addEventListener('submit', event => {
+        if (!form.checkValidity()) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        form.classList.add('was-validated');
+      }, false);
+    });
+  });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@
   <script src="/static/js/html2canvas.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="/static/js/report_window.js" defer></script>
+  <script src="/static/js/validation.js" defer></script>
   {% block head_extra %}{% endblock %}
 </head>
 <body data-admin="{{ 'true' if is_admin else 'false' }}" data-base-path="{{ report_base|default('') }}">

--- a/templates/components/forms.html
+++ b/templates/components/forms.html
@@ -1,0 +1,25 @@
+{% macro text_input(name, label, type='text', value='', required=False, placeholder='', help='', id=None, title='') %}
+  <div class="mb-3">
+    <label for="{{ id or name }}" class="form-label">{{ label }}</label>
+    <input type="{{ type }}" class="form-control" name="{{ name }}" id="{{ id or name }}" value="{{ value }}" placeholder="{{ placeholder }}" {% if title %}title="{{ title }}"{% endif %}{% if required %} required{% endif %}>
+    {% if help %}<div class="form-text">{{ help }}</div>{% endif %}
+    <div class="invalid-feedback">Please provide a valid {{ label|lower }}.</div>
+  </div>
+{% endmacro %}
+
+{% macro select_input(name, label, options, value='', required=False, help='', id=None, title='') %}
+  <div class="mb-3">
+    <label for="{{ id or name }}" class="form-label">{{ label }}</label>
+    <select class="form-select" name="{{ name }}" id="{{ id or name }}" {% if title %}title="{{ title }}"{% endif %}{% if required %} required{% endif %}>
+      {% for opt in options %}
+      <option value="{{ opt }}"{% if opt == value %} selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+    {% if help %}<div class="form-text">{{ help }}</div>{% endif %}
+    <div class="invalid-feedback">Please select a {{ label|lower }}.</div>
+  </div>
+{% endmacro %}
+
+{% macro button(text, type='submit', style='primary', id=None, title='') %}
+  <button type="{{ type }}" class="btn btn-{{ style }}"{% if id %} id="{{ id }}"{% endif %}{% if title %} title="{{ title }}"{% endif %}>{{ text }}</button>
+{% endmacro %}

--- a/templates/jobs.html
+++ b/templates/jobs.html
@@ -1,13 +1,14 @@
 {% extends 'base.html' %}
+{% import 'components/forms.html' as forms %}
 {% block title %}Jobs Dashboard{% endblock %}
 {% block content %}
   <a href="/">← Home</a>
   <h1>Jobs Dashboard</h1>
 
-  <form id="add-form">
+  <form id="add-form" class="needs-validation" novalidate>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <input type="text" id="name" placeholder="New job name" required>
-    <button type="submit">Add Job</button>
+    {{ forms.text_input('name', 'New Job Name', required=True, id='name') }}
+    {{ forms.button('Add Job') }}
   </form>
 
   <table id="jobs-table">
@@ -17,17 +18,12 @@
     <tbody></tbody>
   </table>
 
-  <form id="update-form">
+  <form id="update-form" class="needs-validation" novalidate>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <input type="number" id="job_id" placeholder="Job ID" required>
-    <select id="status">
-      <option>Waiting</option>
-      <option>In Progress</option>
-      <option>Blocked</option>
-      <option>Done</option>
-    </select>
-    <input type="text" id="location" placeholder="Location" required>
-    <button type="submit">Update Job</button>
+    {{ forms.text_input('job_id', 'Job ID', type='number', required=True, id='job_id') }}
+    {{ forms.select_input('status', 'Status', ['Waiting','In Progress','Blocked','Done'], id='status') }}
+    {{ forms.text_input('location', 'Location', required=True, id='location') }}
+    {{ forms.button('Update Job') }}
   </form>
 
   <script src="{{ url_for('static', filename='js/jobs.js') }}"></script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,24 +1,17 @@
 {% extends 'base.html' %}
+{% import 'components/forms.html' as forms %}
 {% block title %}Login{% endblock %}
 {% block content %}
   <div class="action-panel" style="max-width:300px;margin:100px auto;">
     <div class="action-card">
       <img src="/static/images/company-logo.png" alt="Company Logo" style="display:block;margin:0 auto 20px;">
       <h1>Login</h1>
-      <form method="post">
+      <form method="post" class="needs-validation" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <label>User
-          <select name="username">
-            {% for u in users %}
-            <option value="{{ u }}">{{ u }}</option>
-            {% endfor %}
-          </select>
-        </label><br>
-        <label>Password
-          <input type="password" name="password" required>
-        </label><br>
-        <button type="submit">Login</button>
-        {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+        {{ forms.select_input('username', 'User', users, required=True) }}
+        {{ forms.text_input('password', 'Password', type='password', required=True) }}
+        {{ forms.button('Login') }}
+        {% if error %}<p class="text-danger mt-2">{{ error }}</p>{% endif %}
       </form>
     </div>
   </div>

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/forms.html' as forms %}
 {% block title %}Verified Part Markings{% endblock %}
 {% block head_extra %}
   <script src="/static/js/part_markings.js" defer></script>
@@ -12,46 +13,32 @@
         <div class="action-card">
           <h2>Search Verified Part</h2>
           <p class="desc">Enter a part number to highlight it in the table.</p>
-          <label for="search-part-number">Part Number</label>
-          <input type="text" id="search-part-number" placeholder="e.g., 10-1000" aria-label="Part number to search" title="Part number to locate">
-          <p class="field-desc">Highlight matching part number in the table.</p>
-          <button id="search-btn" type="button" title="Highlight matching part number">Search</button>
+          {{ forms.text_input('search-part-number', 'Part Number', placeholder='e.g., 10-1000', help='Highlight matching part number in the table.', id='search-part-number', title='Part number to locate') }}
+          {{ forms.button('Search', type='button', id='search-btn', title='Highlight matching part number') }}
         </div>
         {% if is_admin or permissions['part_markings'] %}
         <div class="action-card">
           <h2>Add New Entry</h2>
           <p class="desc">Use this form to add a single verified part marking.</p>
-          <form method="post">
+          <form method="post" class="needs-validation" novalidate>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <label>Part Number
-              <input type="text" name="part_number" required title="Unique part number">
-            </label><br>
-            <label>Mfg Number 1
-              <input type="text" name="mfg_number1" title="Manufacturer number 1">
-            </label><br>
-            <label>Mfg Number 2
-              <input type="text" name="mfg_number2" title="Manufacturer number 2">
-            </label><br>
-            <label>Manufacturer
-              <input type="text" name="manufacturer" title="Manufacturer name">
-            </label><br>
-            <label>Verified Markings
-              <input type="text" name="verified_markings" title="Verified markings text">
-            </label><br>
+            {{ forms.text_input('part_number', 'Part Number', required=True, title='Unique part number') }}
+            {{ forms.text_input('mfg_number1', 'Mfg Number 1', title='Manufacturer number 1') }}
+            {{ forms.text_input('mfg_number2', 'Mfg Number 2', title='Manufacturer number 2') }}
+            {{ forms.text_input('manufacturer', 'Manufacturer', title='Manufacturer name') }}
+            {{ forms.text_input('verified_markings', 'Verified Markings', title='Verified markings text') }}
             <p class="field-desc">Add the new part marking to the table.</p>
-            <button type="submit" title="Add new part marking">Add</button>
+            {{ forms.button('Add', title='Add new part marking') }}
           </form>
         </div>
         <div class="action-card">
           <h2>Bulk Upload</h2>
           <p class="desc">Upload an Excel file to add multiple entries at once.</p>
-          <form method="post" enctype="multipart/form-data">
+          <form method="post" enctype="multipart/form-data" class="needs-validation" novalidate>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <label>Excel File
-              <input type="file" name="excel_file" accept=".xlsx,.xls" required title="Excel file containing part markings">
-            </label><br>
+            {{ forms.text_input('excel_file', 'Excel File', type='file', required=True, title='Excel file containing part markings') }}
             <p class="field-desc">Import rows from the selected spreadsheet.</p>
-            <button type="submit" title="Upload spreadsheet">Upload</button>
+            {{ forms.button('Upload', title='Upload spreadsheet') }}
           </form>
         </div>
         {% endif %}

--- a/templates/rework.html
+++ b/templates/rework.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/forms.html' as forms %}
 {% block title %}Rework - Stencil Lookup{% endblock %}
 {% block head_extra %}
   <script src="/static/js/stencil_lookup.js" defer></script>
@@ -12,33 +13,21 @@
         <div class="action-card">
           <h2>Search Stencil</h2>
           <p class="desc">Enter a part number to highlight matching stencils.</p>
-          <label for="search-part-number">Part Number</label>
-          <input type="text" id="search-part-number" placeholder="e.g., 10-1000" aria-label="Part number to search" title="Part number to locate">
-          <p class="field-desc">Highlight matching part number in the table.</p>
-          <button id="search-btn" type="button" title="Highlight matching part number">Search</button>
+          {{ forms.text_input('search-part-number', 'Part Number', placeholder='e.g., 10-1000', help='Highlight matching part number in the table.', id='search-part-number', title='Part number to locate') }}
+          {{ forms.button('Search', type='button', id='search-btn', title='Highlight matching part number') }}
         </div>
         <div class="action-card">
           <h2>Add New Entry</h2>
           <p class="desc">Use this form to add a stencil and associated parts.</p>
-          <form method="post">
+          <form method="post" class="needs-validation" novalidate>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <label>Stencil Number
-              <input type="text" name="stencil_number" required title="Stencil number">
-            </label><br>
-            <label>Part Number(s)
-              <input type="text" name="part_number" required title="Comma separated part numbers">
-            </label><br>
-            <label>Ref
-              <input type="text" name="ref" title="Reference designator">
-            </label><br>
-            <label>Description
-              <input type="text" name="description" title="Description">
-            </label><br>
-            <label>Location Of Stencil
-              <input type="text" name="location_of_stencil" title="Location of stencil">
-            </label><br>
+            {{ forms.text_input('stencil_number', 'Stencil Number', required=True, title='Stencil number') }}
+            {{ forms.text_input('part_number', 'Part Number(s)', required=True, title='Comma separated part numbers') }}
+            {{ forms.text_input('ref', 'Ref', title='Reference designator') }}
+            {{ forms.text_input('description', 'Description', title='Description') }}
+            {{ forms.text_input('location_of_stencil', 'Location Of Stencil', title='Location of stencil') }}
             <p class="field-desc">Add the stencil to the table.</p>
-            <button type="submit" title="Add new stencil">Add</button>
+            {{ forms.button('Add', title='Add new stencil') }}
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add reusable Jinja macros for form fields and buttons
- enhance login and several other pages to use styled components
- introduce Bootstrap validation script for client-side feedback

## Testing
- `pytest` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ae40f29600832595c4a65dd4de1d7e