### PR TITLE
feat: add theme variables and toggle

### DIFF
--- a/static/css/bootstrap_overrides.css
+++ b/static/css/bootstrap_overrides.css
@@ -4,6 +4,12 @@
   --bs-primary: var(--color-accent);
 }
 
+body.dark-mode {
+  --bs-body-bg: var(--color-white);
+  --bs-body-color: var(--color-black);
+  --bs-primary: var(--color-accent);
+}
+
 .navbar {
   background-color: var(--color-accent);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,17 +1,34 @@
-:root {
-  --color-black: #000000;
-  --color-white: #f5f5f5;
-  --color-accent: #3b836d;
-}
-
 body {
-  font-family: Arial, sans-serif;
+  font-family: var(--font-body);
   margin: 20px;
   background: var(--color-white);
   color: var(--color-black);
 }
-h1, p { color: var(--color-black); }
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  font-weight: var(--heading-weight);
+  color: var(--color-black);
+}
+p { color: var(--color-black); }
 a { color: var(--color-accent); }
+
+/* Buttons */
+.btn {
+  font-weight: var(--button-font-weight);
+}
+.btn-primary {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-white);
+}
+
+/* Alerts */
+.alert {
+  border: 1px solid var(--color-black);
+  color: var(--color-black);
+}
+.alert-warning { background: var(--color-warning-bg); }
+.alert-danger { background: var(--color-danger-bg); }
 
 /* Accessible focus outlines for navigation */
 .navbar-nav .nav-link:focus,
@@ -24,8 +41,8 @@ a { color: var(--color-accent); }
 .job-previews { margin: 0 -20px 20px -20px; width: calc(100% + 40px); }
 .job-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; width: 100%; }
 .job-preview { margin-bottom: 0; padding: 10px; border: 1px solid var(--color-black); border-radius: 4px; }
-.job-preview.warning { background: #fff3cd; }
-.job-preview.danger { background: #f8d7da; }
+.job-preview.warning { background: var(--color-warning-bg); }
+.job-preview.danger { background: var(--color-danger-bg); }
 .job-preview ul { list-style: none; padding-left: 0; margin: 5px 0 0 0; }
 .job-preview li { font-family: monospace; }
 
@@ -52,8 +69,8 @@ table thead th {
   z-index: 1;
 }
 .highlight { background: yellow; }
-.threshold-red { background: #f8d7da; }
-.threshold-yellow { background: #fff3cd; }
+.threshold-red { background: var(--color-danger-bg); }
+.threshold-yellow { background: var(--color-warning-bg); }
 
 /* Action panels */
 .action-panel {
@@ -367,25 +384,6 @@ table thead th {
 }
 
 /* Dark mode styles */
-body.dark-mode {
-  background: var(--color-black);
-  color: var(--color-white);
-}
-body.dark-mode h1,
-body.dark-mode p,
-body.dark-mode label,
-body.dark-mode span {
-  color: var(--color-white);
-}
-body.dark-mode a { color: var(--color-accent); }
-body.dark-mode .action-card { background: var(--color-black); border-color: var(--color-white); }
-body.dark-mode .action-card p { color: var(--color-white); }
-body.dark-mode table { border-color: var(--color-white); }
-body.dark-mode th,
-body.dark-mode td { border-color: var(--color-white); }
-body.dark-mode table thead th { background: var(--color-black); }
-body.dark-mode .job-preview.warning { background: #bdbd3a; border-color: #b7b700; color: #fff; }
-body.dark-mode .job-preview.danger { background: #a72828; border-color: #660000; color: #fff; }
 
 /* SQL popup windows */
 .sql-popup {

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,26 @@
+/* Centralized theme variables for light and dark modes */
+:root {
+  /* Base colors */
+  --color-black: #000000;
+  --color-white: #f5f5f5;
+  --color-accent: #3b836d;
+
+  /* Extended palette */
+  --color-warning-bg: #fff3cd;
+  --color-danger-bg: #f8d7da;
+
+  /* Typography */
+  --font-body: Arial, sans-serif;
+  --font-heading: 'Segoe UI', Tahoma, sans-serif;
+  --heading-weight: 600;
+  --button-font-weight: 500;
+}
+
+/* Dark mode overrides */
+body.dark-mode {
+  --color-black: #f5f5f5;
+  --color-white: #000000;
+  --color-accent: #3b836d;
+  --color-warning-bg: #bdbd3a;
+  --color-danger-bg: #a72828;
+}

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -5,11 +5,15 @@ document.addEventListener('DOMContentLoaded', () => {
   if (saved === 'dark') {
     document.body.classList.add('dark-mode');
     toggle.textContent = 'Light Mode';
+    toggle.classList.remove('btn-light');
+    toggle.classList.add('btn-dark');
   }
   toggle.addEventListener('click', () => {
     document.body.classList.toggle('dark-mode');
     const isDark = document.body.classList.contains('dark-mode');
     toggle.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+    toggle.classList.toggle('btn-light', !isDark);
+    toggle.classList.toggle('btn-dark', isDark);
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
   });
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>{% block title %}SPCApp{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/theme.css">
   <link rel="stylesheet" href="/static/css/style.css">
   <link rel="stylesheet" href="/static/css/bootstrap_overrides.css">
   <link rel="icon" type="image/png" href="/static/images/company-logo.png">


### PR DESCRIPTION
## Summary
- centralize color and typography variables for light and dark themes
- style headings, buttons and alerts using the new variables
- enhance theme toggle to swap button style

## Testing
- `pytest` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ae426af1e08325a691cc510cdd0356