### PR TITLE
Align navbar styling with app theme

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,8 +1,12 @@
 body {
   font-family: var(--font-body);
-  margin: 20px;
+  margin: 0;
   background: var(--color-white);
   color: var(--color-black);
+}
+
+main {
+  margin: 20px;
 }
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-heading);
@@ -11,6 +15,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 p { color: var(--color-black); }
 a { color: var(--color-accent); }
+
+.navbar {
+  background-color: var(--color-accent) !important;
+}
 
 /* Buttons */
 .btn {

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -15,7 +15,6 @@
     <script src="{{ url_for('static', filename='js/moat_sql.js') }}" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Data Analysis - PPM MOAT</h1>
   {% if not show_moat %}
     <div style="display:flex; flex-direction:column; gap:10px; width:fit-content;">

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -21,7 +21,6 @@
   <script src="{{ url_for('static', filename='js/aoi_sql.js') }}" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>AOI Daily Report</h1>
   <div id="container">
     <div id="aoi-actions">

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
 </head>
 <body data-admin="{{ 'true' if is_admin else 'false' }}" data-base-path="{{ report_base|default('') }}">
   {% if current_user %}
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-3" aria-label="Main navigation">
+  <nav class="navbar navbar-expand-lg navbar-dark" aria-label="Main navigation">
     <div class="container-fluid">
       <a class="navbar-brand" href="{{ url_for('home') }}">SPCApp</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -75,6 +75,7 @@
     </div>
   </nav>
   {% endif %}
+  <main>
   {% with messages = get_flashed_messages() %}
     {% if messages %}
       <ul class="flash-messages">
@@ -88,6 +89,7 @@
   <button id="report-button" title="Generate Report" onclick="openReportWindow()">\u270e</button>
   {% endif %}
   {% block content %}{% endblock %}
+  </main>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       if (localStorage.getItem('report-window-open') === 'true' && typeof openReportWindow === 'function') {

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -5,7 +5,6 @@
   <script src="/static/js/chart-popup.js" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Control Chart – Average FalseCall Rate</h1>
   <div class="chart-container">
     <canvas id="popup-chart" height="200"></canvas>

--- a/templates/compare_aoi_fi.html
+++ b/templates/compare_aoi_fi.html
@@ -12,7 +12,6 @@
   <script src="{{ url_for('static', filename='js/aoi_fi_compare.js') }}" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="{{ url_for('home') }}">&larr; Back to Home</a>
   <h1>AOI vs Final Inspect Comparison</h1>
   <form method="get" style="margin-bottom:20px;">
     <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label>

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Docs{% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1 id="top">Documentation</h1>
   <div class="action-panel">
     <div class="action-card">

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -21,7 +21,6 @@
   <script src="{{ url_for('static', filename='js/aoi_sql.js') }}" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Final Inspect Daily Report</h1>
   <div id="container">
     <div id="aoi-actions">

--- a/templates/jobs.html
+++ b/templates/jobs.html
@@ -2,7 +2,6 @@
 {% import 'components/forms.html' as forms %}
 {% block title %}Jobs Dashboard{% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Jobs Dashboard</h1>
 
   <form id="add-form" class="needs-validation" novalidate>

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -5,7 +5,6 @@
   <script src="/static/js/part_markings.js" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Verified Part Markings</h1>
   <div id="container">
     <div id="markings-actions">

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -10,7 +10,6 @@
   <script src="{{ url_for('static', filename='js/generate_reports.js') }}" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Reports</h1>
   <label for="start-date">Start Date</label>
   <input type="date" id="start-date">

--- a/templates/rework.html
+++ b/templates/rework.html
@@ -5,7 +5,6 @@
   <script src="/static/js/stencil_lookup.js" defer></script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Stencil/Part Number Lookup</h1>
   <div id="container">
     <div id="stencil-actions">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -20,7 +20,6 @@ function toggleAddUser(){
 </script>
 {% endblock %}
 {% block content %}
-  <a href="/">← Home</a>
   <h1>Settings</h1>
   <div class="tab-buttons">
     <button type="button" onclick="showTab('users')">User Management</button>


### PR DESCRIPTION
## Summary
- Use app accent green for navbar and remove outer margin
- Remove redundant Home links from feature templates
- Wrap page content in `<main>` with margin for consistent spacing

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae467ba3a08325b397a3073359a412