### PR TITLE
Ensure responsive chart sizing in AOI dashboard

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -195,11 +195,13 @@ table thead th {
   box-sizing: border-box;
   min-width: 300px;
   height: 40vh;
+  overflow: hidden;
 }
 
 .chart-widget canvas {
-  width: 100% !important;
-  height: 100% !important;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 /* Analysis split layout */

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -38,6 +38,8 @@ window.addEventListener('DOMContentLoaded', () => {
         ]
       },
       options: {
+        responsive: true,
+        maintainAspectRatio: false,
         scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } },
         plugins: {
           tooltip: {
@@ -74,7 +76,7 @@ window.addEventListener('DOMContentLoaded', () => {
     charts.shift = new Chart(ctx, {
       type: 'bar',
       data: { labels: dates, datasets },
-      options: { scales: { y: { beginAtZero: true } } }
+      options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
     });
   }
 
@@ -95,7 +97,7 @@ window.addEventListener('DOMContentLoaded', () => {
           labels: customerData.map(c => c.customer),
           datasets: [{ label: 'Reject Rate', data: customerData.map(c => c.rate), backgroundColor: 'rgba(255,159,64,0.7)' }]
         },
-        options: { scales: { y: { beginAtZero: true } } }
+        options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
       });
     }
     if (stdCtx) {
@@ -105,6 +107,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const stdev = Math.sqrt(variance);
       const yMax = Math.max(...rates, mean + 3 * stdev, 1);
       const { config } = createStdChartConfig(rates, mean, stdev, yMax);
+      config.options = { ...config.options, responsive: true, maintainAspectRatio: false };
       charts.customerStd = new Chart(stdCtx, config);
       if (summaryEl) summaryEl.textContent = `Avg rate ${mean.toFixed(2)} with std dev ${stdev.toFixed(2)}.`;
     }
@@ -125,6 +128,8 @@ window.addEventListener('DOMContentLoaded', () => {
         datasets: [{ label: 'Yield %', data: values, fill: false, borderColor: 'rgba(75,192,192,1)' }]
       },
       options: {
+        responsive: true,
+        maintainAspectRatio: false,
         scales: { y: { min: yMin, max: 100, ticks: { callback: v => `${v}%` } } }
       }
     });
@@ -249,6 +254,7 @@ window.addEventListener('DOMContentLoaded', () => {
   function showModal(title, config, headers, rows) {
     if (modalChart) modalChart.destroy();
     modalTitle.textContent = title;
+    config.options = { ...config.options, responsive: true, maintainAspectRatio: false };
     modalChart = new Chart(modalCanvas, config);
     modalHead.innerHTML = '<tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr>';
     modalBody.innerHTML = rows.map(r => '<tr>' + r.map(c => `<td>${c}</td>`).join('') + '</tr>').join('');
@@ -269,7 +275,7 @@ window.addEventListener('DOMContentLoaded', () => {
               { label: 'Rejected', data: ops.map(o => o.rejected), backgroundColor: 'rgba(255, 99, 132, 0.7)' }
             ]
           },
-          options: { scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } } }
+          options: { responsive: true, maintainAspectRatio: false, scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } } }
         };
         const rows = ops.map((o, idx) => [isAdmin ? o.operator : `Operator ${idx + 1}`, o.inspected, o.rejected]);
         showModal('Top Operators by Inspected Quantity', config, ['Operator','Inspected','Rejected'], rows);
@@ -285,7 +291,7 @@ window.addEventListener('DOMContentLoaded', () => {
           }),
           backgroundColor: colors[idx % colors.length]
         }));
-        const config = { type: 'bar', data: { labels: dates, datasets }, options: { scales: { y: { beginAtZero: true } } } };
+        const config = { type: 'bar', data: { labels: dates, datasets }, options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } } };
         const rows = shiftData.map(r => [r.report_date, r.shift, r.inspected]);
         showModal('Shift Totals', config, ['Date','Shift','Inspected'], rows);
       } else if (type === 'customer' && customerData) {
@@ -295,7 +301,7 @@ window.addEventListener('DOMContentLoaded', () => {
             labels: customerData.map(c => c.customer),
             datasets: [{ label: 'Reject Rate', data: customerData.map(c => c.rate), backgroundColor: 'rgba(255, 159, 64, 0.7)' }]
           },
-          options: { scales: { y: { beginAtZero: true } } }
+          options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
         };
         const rows = customerData.map(c => [c.customer, c.rate]);
         showModal('Operator Reject Rates', config, ['Customer','Reject Rate'], rows);
@@ -306,6 +312,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const stdev = Math.sqrt(variance);
         const yMax = Math.max(...rates, mean + 3 * stdev, 1);
         const { config, rows } = createStdChartConfig(rates, mean, stdev, yMax);
+        config.options = { ...config.options, responsive: true, maintainAspectRatio: false };
         showModal('Std Dev of Reject Rates per Customer', config, ['Range','Frequency'], rows);
       } else if (type === 'yield' && yieldData) {
         const config = {
@@ -315,6 +322,8 @@ window.addEventListener('DOMContentLoaded', () => {
             datasets: [{ label: 'Yield %', data: yieldData.map(y => y.yield * 100), fill: false, borderColor: 'rgba(75, 192, 192, 1)' }]
           },
           options: {
+            responsive: true,
+            maintainAspectRatio: false,
             scales: {
               y: {
                 beginAtZero: true,
@@ -367,7 +376,7 @@ window.addEventListener('DOMContentLoaded', () => {
               { label: 'Rejected', data: ops.map(o => o.rejected), backgroundColor: 'rgba(255, 99, 132, 0.7)' }
             ]
           },
-          options: { scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } } }
+          options: { responsive: true, maintainAspectRatio: false, scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } } }
         });
       }
     }
@@ -382,7 +391,7 @@ window.addEventListener('DOMContentLoaded', () => {
             labels: shifts.map(s => s.shift),
             datasets: [{ label: 'Inspected', data: shifts.map(s => s.inspected), backgroundColor: 'rgba(75, 192, 192, 0.7)' }]
           },
-          options: { scales: { y: { beginAtZero: true } } }
+          options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
         });
       }
     }
@@ -397,7 +406,7 @@ window.addEventListener('DOMContentLoaded', () => {
             labels: cust.map(c => c.customer),
             datasets: [{ label: 'Reject Rate', data: cust.map(c => c.rate), backgroundColor: 'rgba(255, 159, 64, 0.7)' }]
           },
-          options: { scales: { y: { beginAtZero: true } } }
+          options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
         });
       }
     }
@@ -413,6 +422,8 @@ window.addEventListener('DOMContentLoaded', () => {
             datasets: [{ label: 'Yield %', data: ySeries.map(y => y.yield * 100), fill: false, borderColor: 'rgba(75, 192, 192, 1)' }]
           },
           options: {
+            responsive: true,
+            maintainAspectRatio: false,
             scales: {
               y: {
                 beginAtZero: true,

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -343,7 +343,7 @@
           <div class="report-section" id="daily-report">
             <h2>Daily Report</h2>
             <div class="chart-container">
-              <canvas id="daily-report-canvas" height="200" style="display:none"></canvas>
+              <canvas id="daily-report-canvas" style="display:none"></canvas>
             </div>
             <table id="daily-report-table" style="display:none"></table>
             <label>Margin:
@@ -366,7 +366,7 @@
           <div class="report-section" id="weekly-report">
             <h2>Weekly Report</h2>
             <div class="chart-container">
-              <canvas id="weekly-report-canvas" height="200" style="display:none"></canvas>
+              <canvas id="weekly-report-canvas" style="display:none"></canvas>
             </div>
             <table id="weekly-report-table" style="display:none"></table>
             <label>Margin:
@@ -389,7 +389,7 @@
           <div class="report-section" id="monthly-report">
             <h2>Monthly Report</h2>
             <div class="chart-container">
-              <canvas id="monthly-report-canvas" height="200" style="display:none"></canvas>
+              <canvas id="monthly-report-canvas" style="display:none"></canvas>
             </div>
             <table id="monthly-report-table" style="display:none"></table>
             <label>Margin:
@@ -412,7 +412,7 @@
           <div class="report-section" id="yearly-report">
             <h2>Yearly Report</h2>
             <div class="chart-container">
-              <canvas id="yearly-report-canvas" height="200" style="display:none"></canvas>
+              <canvas id="yearly-report-canvas" style="display:none"></canvas>
             </div>
             <table id="yearly-report-table" style="display:none"></table>
             <label>Margin:
@@ -503,7 +503,7 @@
           </div>
           <div class="modal-body">
             <div class="chart-container">
-              <canvas id="chart-canvas" height="200"></canvas>
+              <canvas id="chart-canvas"></canvas>
             </div>
             <p id="fc-chart-summary" class="chart-summary"></p>
             <table id="fc-data-table"></table>
@@ -530,7 +530,7 @@
           </div>
           <div class="modal-body">
             <div class="chart-container">
-              <canvas id="chart-ng-canvas" height="200"></canvas>
+              <canvas id="chart-ng-canvas"></canvas>
             </div>
             <p id="ng-chart-summary" class="chart-summary"></p>
             <table id="ng-data-table"></table>
@@ -556,7 +556,7 @@
           </div>
           <div class="modal-body">
             <div class="chart-container">
-              <canvas id="chart-stddev-canvas" height="200"></canvas>
+              <canvas id="chart-stddev-canvas"></canvas>
             </div>
             <p id="stddev-chart-summary" class="chart-summary"></p>
             <table id="std-data-table"></table>
@@ -582,7 +582,7 @@
           </div>
           <div class="modal-body">
             <div class="chart-container">
-              <canvas id="chart-ng-stddev-canvas" height="200"></canvas>
+              <canvas id="chart-ng-stddev-canvas"></canvas>
             </div>
             <p id="ng-stddev-chart-summary" class="chart-summary"></p>
             <table id="ng-std-data-table"></table>

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -358,7 +358,7 @@
         </div>
         <div class="modal-body">
           <div class="chart-container">
-            <canvas id="modal-chart" height="200"></canvas>
+            <canvas id="modal-chart"></canvas>
           </div>
           <table id="modal-table">
             <thead></thead>

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -7,6 +7,6 @@
 {% block content %}
   <h1>Control Chart – Average FalseCall Rate</h1>
   <div class="chart-container">
-    <canvas id="popup-chart" height="200"></canvas>
+    <canvas id="popup-chart"></canvas>
   </div>
 {% endblock %}

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -358,7 +358,7 @@
         </div>
         <div class="modal-body">
           <div class="chart-container">
-            <canvas id="modal-chart" height="200"></canvas>
+            <canvas id="modal-chart"></canvas>
           </div>
           <table id="modal-table">
             <thead></thead>


### PR DESCRIPTION
## Summary
- Stop forcing canvas dimensions and hide overflow in chart widgets
- Make all Chart.js instances responsive with relaxed aspect ratio
- Drop hard-coded canvas height attributes so charts size from CSS

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f59cd9c8325810c67c2a02aa86b