### PR TITLE
style: add filter toolbar and enlarge chart widgets

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -183,18 +183,35 @@ table thead th {
 .chart-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 20px;
+  gap: 10px;
 }
 
-.chart-widget {
-  flex: 1 1 calc(50% - 20px);
+.filter-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   background: var(--color-white);
   border: 1px solid var(--color-black);
   border-radius: 8px;
   padding: 10px;
+  margin-bottom: 10px;
+}
+
+.filter-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chart-widget {
+  flex: 1 1 calc(50% - 10px);
+  background: var(--color-white);
+  border: 1px solid var(--color-black);
+  border-radius: 8px;
+  padding: 8px;
   box-sizing: border-box;
   min-width: 300px;
-  height: 40vh;
+  height: 50vh;
   overflow: hidden;
 }
 

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -1,14 +1,6 @@
 window.addEventListener('DOMContentLoaded', () => {
   const basePath = document.body.dataset.basePath || 'aoi';
 
-  const filterBtn = document.getElementById('aoi-filter-btn');
-  const filterForm = document.getElementById('aoi-filter-form');
-  if (filterBtn && filterForm) {
-    filterBtn.addEventListener('click', () => {
-      filterForm.style.display = filterForm.style.display === 'none' ? 'block' : 'none';
-    });
-  }
-
   const getData = id => {
     const el = document.getElementById(id);
     return el ? JSON.parse(el.textContent) : null;

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -99,13 +99,11 @@
       <div id="analysis" class="tab-content">
         <div class="analysis-layout">
           <div class="analysis-charts">
-            <div class="action-card">
-              <h2>Data Mining Filters</h2>
-              <button id="aoi-filter-btn" title="Show or hide filter options">Filter Options</button>
-              <form id="aoi-filter-form" method="get" action="/aoi" style="display:none; margin-top:10px;">
+            <div class="filter-toolbar">
+              <form id="aoi-filter-form" method="get" action="/aoi">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label><br>
-                <label>End: <input type="date" name="end" value="{{ end or '' }}"></label><br>
+                <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label>
+                <label>End: <input type="date" name="end" value="{{ end or '' }}"></label>
                 <label>Customer:
                   <select name="customer">
                     <option value="">All</option>
@@ -113,7 +111,7 @@
                     <option value="{{ c }}" {% if c == selected_customer %}selected{% endif %}>{{ c }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <label>Shift:
                   <select name="shift">
                     <option value="">All</option>
@@ -121,7 +119,7 @@
                     <option value="{{ s }}" {% if s == selected_shift %}selected{% endif %}>{{ s }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <label>Operator:
                   <select name="operator">
                     <option value="">All</option>
@@ -129,7 +127,7 @@
                     <option value="{{ o }}" {% if o == selected_operator %}selected{% endif %}>{{ o }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <label>Assembly:
                   <select name="assembly">
                     <option value="">All</option>
@@ -137,7 +135,7 @@
                     <option value="{{ a }}" {% if a == selected_assembly %}selected{% endif %}>{{ a }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <button type="submit">Apply</button>
               </form>
             </div>

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -99,13 +99,11 @@
       <div id="analysis" class="tab-content">
         <div class="analysis-layout">
           <div class="analysis-charts">
-            <div class="action-card">
-              <h2>Data Mining Filters</h2>
-              <button id="aoi-filter-btn" title="Show or hide filter options">Filter Options</button>
-              <form id="aoi-filter-form" method="get" action="/final-inspect" style="display:none; margin-top:10px;">
+            <div class="filter-toolbar">
+              <form id="aoi-filter-form" method="get" action="/final-inspect">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label><br>
-                <label>End: <input type="date" name="end" value="{{ end or '' }}"></label><br>
+                <label>Start: <input type="date" name="start" value="{{ start or '' }}"></label>
+                <label>End: <input type="date" name="end" value="{{ end or '' }}"></label>
                 <label>Customer:
                   <select name="customer">
                     <option value="">All</option>
@@ -113,7 +111,7 @@
                     <option value="{{ c }}" {% if c == selected_customer %}selected{% endif %}>{{ c }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <label>Shift:
                   <select name="shift">
                     <option value="">All</option>
@@ -121,7 +119,7 @@
                     <option value="{{ s }}" {% if s == selected_shift %}selected{% endif %}>{{ s }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <label>Operator:
                   <select name="operator">
                     <option value="">All</option>
@@ -129,7 +127,7 @@
                     <option value="{{ o }}" {% if o == selected_operator %}selected{% endif %}>{{ o }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <label>Assembly:
                   <select name="assembly">
                     <option value="">All</option>
@@ -137,7 +135,7 @@
                     <option value="{{ a }}" {% if a == selected_assembly %}selected{% endif %}>{{ a }}</option>
                     {% endfor %}
                   </select>
-                </label><br>
+                </label>
                 <button type="submit">Apply</button>
               </form>
             </div>


### PR DESCRIPTION
## Summary
- convert AOI and Final Inspect data mining filters into a top toolbar
- enlarge chart widgets and reduce spacing
- remove JS filter toggle

## Testing
- `SECRET_KEY=testing pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae528e5a648325be2ac528330fc689