### PR TITLE
Refine chart widget sizing and add detail modal class

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -211,11 +211,27 @@ table thead th {
   padding: 8px;
   box-sizing: border-box;
   min-width: 300px;
-  height: 50vh;
+  height: 240px;
   overflow: hidden;
 }
 
 .chart-widget canvas {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+@media (max-width: 600px) {
+  .chart-widget {
+    height: 200px;
+  }
+}
+
+.chart-widget--detail {
+  height: 70vh;
+}
+
+.chart-widget--detail canvas {
   width: 100%;
   height: 100%;
   object-fit: contain;

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -502,7 +502,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <div class="chart-container">
+            <div class="chart-container chart-widget--detail">
               <canvas id="chart-canvas"></canvas>
             </div>
             <p id="fc-chart-summary" class="chart-summary"></p>
@@ -529,7 +529,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <div class="chart-container">
+            <div class="chart-container chart-widget--detail">
               <canvas id="chart-ng-canvas"></canvas>
             </div>
             <p id="ng-chart-summary" class="chart-summary"></p>
@@ -555,7 +555,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <div class="chart-container">
+            <div class="chart-container chart-widget--detail">
               <canvas id="chart-stddev-canvas"></canvas>
             </div>
             <p id="stddev-chart-summary" class="chart-summary"></p>
@@ -581,7 +581,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <div class="chart-container">
+            <div class="chart-container chart-widget--detail">
               <canvas id="chart-ng-stddev-canvas"></canvas>
             </div>
             <p id="ng-stddev-chart-summary" class="chart-summary"></p>

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -357,7 +357,7 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <div class="chart-container">
+          <div class="chart-container chart-widget--detail">
             <canvas id="modal-chart"></canvas>
           </div>
           <table id="modal-table">

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -356,7 +356,7 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <div class="chart-container">
+          <div class="chart-container chart-widget--detail">
             <canvas id="modal-chart"></canvas>
           </div>
           <table id="modal-table">


### PR DESCRIPTION
## Summary
- reduce chart widget height to 240px with a 200px small-screen override
- introduce `.chart-widget--detail` for taller charts in modals and apply to modal templates

## Testing
- `pytest` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5a8165188325b517c2a014933549