### PR TITLE
Enable full table filtering and model toolbar

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -31,10 +31,9 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   // Model filter for MOAT table
-  const modelFilter = document.getElementById('model-filter');
-  if (modelFilter) {
-    modelFilter.addEventListener('change', () => {
-      const value = modelFilter.value;
+  const modelFilterBtns = document.querySelectorAll('.model-filter-btn');
+  if (modelFilterBtns.length) {
+    function applyModelFilter(value) {
       const rows = document.querySelectorAll('#moat-table tbody tr');
       rows.forEach(row => {
         const name = row.cells[0].textContent.toUpperCase();
@@ -44,8 +43,15 @@ window.addEventListener('DOMContentLoaded', () => {
           (value === 'th' && name.includes('TH'));
         row.style.display = show ? '' : 'none';
       });
+    }
+    modelFilterBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        modelFilterBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        applyModelFilter(btn.dataset.filter);
+      });
     });
-    modelFilter.dispatchEvent(new Event('change'));
+    applyModelFilter('all');
   }
 
   const refreshBtn = document.getElementById('ppm-refresh-btn');

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -323,6 +323,9 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   const table = document.querySelector(`#${basePath}-table table`);
+  if (table && window.jQuery) {
+    $(table).DataTable();
+  }
   if (table) {
     table.addEventListener('click', async e => {
       if (!e.target.classList.contains('delete-row')) return;

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -445,12 +445,12 @@
         <button id="ppm-refresh-btn">Report Refresh</button>
         {% endif %}
         <div id="model-filter-container">
-          <label for="model-filter">Show Models</label>
-          <select id="model-filter">
-            <option value="all">All</option>
-            <option value="smt">SMT</option>
-            <option value="th">TH</option>
-          </select>
+          <span>Show Models</span>
+          <div class="model-toolbar">
+            <button type="button" class="model-filter-btn active" data-filter="all">All</button>
+            <button type="button" class="model-filter-btn" data-filter="smt">SMT</button>
+            <button type="button" class="model-filter-btn" data-filter="th">TH</button>
+          </div>
         </div>
         <table>
           <thead><tr>


### PR DESCRIPTION
## Summary
- Replace model filter dropdown with a button-based toolbar
- Initialize DataTables on main report tables for full-table filtering
- Update analysis script to handle new toolbar interactions

## Testing
- `SECRET_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae633b9ab08325b459399c66209a27