### PR TITLE
Destroy existing report charts before creating new ones

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -677,6 +677,11 @@ window.addEventListener('DOMContentLoaded', () => {
     fetch(`/analysis/report-data?freq=${freq}`)
       .then(res => res.json())
       .then(data => {
+        if (reportCharts[freq]) {
+          reportCharts[freq].destroy();
+          const ctx = canvas.getContext('2d');
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+        }
         reportCharts[freq] = new Chart(canvas, {
           type: 'line',
           data: {


### PR DESCRIPTION
## Summary
- Prevent chart accumulation in Analysis reports by destroying and clearing existing charts before instantiation.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeeda671808325a103785df040d806