### PR TITLE
Weight FI rejects by AOI inspection share

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Material information is available through the route
 `/sap/material/<material_id>` which returns JSON containing the material
 `id` and `description`.
 
+## Operator Grading
+
+The `/analysis/operator-grades` route compares AOI and Final Inspect
+defects per operator. When a job is inspected by multiple operators, the
+FI rejects for that job are divided based on each operator's share of the
+AOI inspected quantity. Coverage is calculated as:
+
+```
+AOI_rejected / (AOI_rejected + weighted_FI_rejected)
+```
+
+The coverage percentage determines the letter grade (A–D).
+
 ## Analysis Comparison API
 
 The analysis module exposes a small JSON endpoint for correlating


### PR DESCRIPTION
## Summary
- Allocate FI rejects per operator proportionally to AOI inspected quantity via new job_totals CTE
- Test that FI defects are split by inspection share for jobs with multiple operators
- Document operator grading logic and weighting formula

## Testing
- `SECRET_KEY=test pytest tests/test_operator_grades.py`

------
https://chatgpt.com/codex/tasks/task_e_68aeeea8af1c8325bb89cacbcacf9f5a