### PR TITLE
Tighten AOI and FI analysis chart sizing

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -225,20 +225,22 @@ table thead th {
   display: flex;
   gap: 20px;
   align-items: flex-start;
+  flex-wrap: wrap;
 }
 
 .chart-box {
-  flex: 0 0 60%;
+  flex: 0 0 100%;
+  width: 75vw;
 }
 
 .chart-box canvas {
   width: 100%;
-  height: 240px;
+  height: 45vw;
   object-fit: contain;
 }
 
 .chart-details {
-  flex: 1;
+  flex: 1 1 100%;
   font-size: 0.9em;
 }
 
@@ -249,7 +251,8 @@ table thead th {
 }
 
 .chart-widget--detail {
-  height: 70vh;
+  width: 75vw;
+  height: 45vw;
 }
 
 .chart-widget--detail canvas {
@@ -266,14 +269,14 @@ table thead th {
 }
 
 .analysis-charts {
-  flex: 1 1 60%;
+  flex: 1 1 75%;
   display: flex;
   flex-direction: column;
   gap: 20px;
 }
 
 .analysis-table {
-  flex: 1 1 40%;
+  flex: 1 1 25%;
   overflow: auto;
 }
 


### PR DESCRIPTION
## Summary
- Reduce vertical stretching by constraining AOI and FI analysis charts to 75% viewport width with proportional height
- Adjust analysis layout and chart containers to wrap details below charts for better readability

## Testing
- `pytest -q` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68aef04efe048325b9ebf6bdce63c787