### PR TITLE
Fix chart canvas sizing

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -497,10 +497,9 @@ table thead th {
 }
 
 /* Chart canvas sizing */
-#chart-canvas {
-  width: 100%;
-  height: auto;
-  min-width: 600px; /* Ensure enough width for labels */
+canvas.chart-canvas {
+  width: 800px;
+  height: 400px;
 }
 
 /* Stats alignment */

--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -307,6 +307,8 @@ window.addEventListener('DOMContentLoaded', () => {
               ]
             },
             options: {
+              responsive: false,
+              maintainAspectRatio: false,
               layout: { padding: { top: 20 } },
               scales: { y: { beginAtZero: true, max: yMax } },
               plugins: {
@@ -430,6 +432,8 @@ window.addEventListener('DOMContentLoaded', () => {
               ]
             },
             options: {
+              responsive: false,
+              maintainAspectRatio: false,
               layout: { padding: { top: 20 } },
               scales: { y: { beginAtZero: true, max: yMax } },
               plugins: {
@@ -496,7 +500,7 @@ window.addEventListener('DOMContentLoaded', () => {
           const rates = data.rates.map(r => r.rate).filter(r => r <= yMax);
           if (stdChartInstance) stdChartInstance.destroy();
           if (!rates.length) {
-            stdChartInstance = new Chart(stdCtx, { type: 'bar', data: { labels: [], datasets: [] } });
+            stdChartInstance = new Chart(stdCtx, { type: 'bar', data: { labels: [], datasets: [] }, options: { responsive: false, maintainAspectRatio: false } });
             document.getElementById('stddev-chart-summary').textContent = 'No data.';
             chartStdModal.show();
             return;
@@ -504,6 +508,9 @@ window.addEventListener('DOMContentLoaded', () => {
           const mean = data.mean;
           const stdev = data.stdev;
           const { config, rows } = createStdChartConfig(rates, mean, stdev, yMax);
+          config.options = config.options || {};
+          config.options.responsive = false;
+          config.options.maintainAspectRatio = false;
           stdChartInstance = new Chart(stdCtx, config);
           const stdTable = document.getElementById('std-data-table');
           if (stdTable) {
@@ -545,7 +552,7 @@ window.addEventListener('DOMContentLoaded', () => {
           const rates = data.rates.map(r => r.rate).filter(r => r <= yMax);
           if (ngStdChartInstance) ngStdChartInstance.destroy();
           if (!rates.length) {
-            ngStdChartInstance = new Chart(ngStdCtx, { type: 'bar', data: { labels: [], datasets: [] } });
+            ngStdChartInstance = new Chart(ngStdCtx, { type: 'bar', data: { labels: [], datasets: [] }, options: { responsive: false, maintainAspectRatio: false } });
             document.getElementById('ng-stddev-chart-summary').textContent = 'No data.';
             chartNgStdModal.show();
             return;
@@ -558,6 +565,9 @@ window.addEventListener('DOMContentLoaded', () => {
             lineColor: 'rgba(153, 102, 255, 1)',
             decimals: 3
           });
+          config.options = config.options || {};
+          config.options.responsive = false;
+          config.options.maintainAspectRatio = false;
           ngStdChartInstance = new Chart(ngStdCtx, config);
           const ngStdTable = document.getElementById('ng-std-data-table');
           if (ngStdTable) {
@@ -691,7 +701,11 @@ window.addEventListener('DOMContentLoaded', () => {
               { label: 'NG PPM', data: data.ng_ppm, borderColor: 'red', fill: false }
             ]
           },
-          options: { scales: { y: { beginAtZero: true } } }
+          options: {
+            responsive: false,
+            maintainAspectRatio: false,
+            scales: { y: { beginAtZero: true } }
+          }
         });
         if (table) {
           table.innerHTML = '<thead><tr><th>Period</th><th>Total Boards</th><th>FalseCall PPM</th><th>NG PPM</th></tr></thead><tbody></tbody>';

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -503,7 +503,7 @@
           </div>
           <div class="modal-body">
             <div class="chart-container chart-widget--detail">
-              <canvas id="chart-canvas"></canvas>
+              <canvas id="chart-canvas" class="chart-canvas"></canvas>
             </div>
             <p id="fc-chart-summary" class="chart-summary"></p>
             <table id="fc-data-table"></table>
@@ -530,7 +530,7 @@
           </div>
           <div class="modal-body">
             <div class="chart-container chart-widget--detail">
-              <canvas id="chart-ng-canvas"></canvas>
+              <canvas id="chart-ng-canvas" class="chart-canvas"></canvas>
             </div>
             <p id="ng-chart-summary" class="chart-summary"></p>
             <table id="ng-data-table"></table>
@@ -556,7 +556,7 @@
           </div>
           <div class="modal-body">
             <div class="chart-container chart-widget--detail">
-              <canvas id="chart-stddev-canvas"></canvas>
+              <canvas id="chart-stddev-canvas" class="chart-canvas"></canvas>
             </div>
             <p id="stddev-chart-summary" class="chart-summary"></p>
             <table id="std-data-table"></table>


### PR DESCRIPTION
## Summary
- Add shared `chart-canvas` class to analysis canvases
- Give `.chart-canvas` fixed dimensions and disable responsive resizing in Chart.js

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af037f1f888325b40e4f2d7544d2f6