### PR TITLE
Add fixed point radius for analysis charts

### DIFF
--- a/static/js/analysis.js
+++ b/static/js/analysis.js
@@ -309,6 +309,7 @@ window.addEventListener('DOMContentLoaded', () => {
             options: {
               responsive: false,
               maintainAspectRatio: false,
+              elements: { point: { radius: 3, hoverRadius: 3 } },
               layout: { padding: { top: 20 } },
               scales: { y: { beginAtZero: true, max: yMax } },
               plugins: {
@@ -434,6 +435,7 @@ window.addEventListener('DOMContentLoaded', () => {
             options: {
               responsive: false,
               maintainAspectRatio: false,
+              elements: { point: { radius: 3, hoverRadius: 3 } },
               layout: { padding: { top: 20 } },
               scales: { y: { beginAtZero: true, max: yMax } },
               plugins: {
@@ -499,18 +501,19 @@ window.addEventListener('DOMContentLoaded', () => {
         .then(data => {
           const rates = data.rates.map(r => r.rate).filter(r => r <= yMax);
           if (stdChartInstance) stdChartInstance.destroy();
-          if (!rates.length) {
-            stdChartInstance = new Chart(stdCtx, { type: 'bar', data: { labels: [], datasets: [] }, options: { responsive: false, maintainAspectRatio: false } });
-            document.getElementById('stddev-chart-summary').textContent = 'No data.';
-            chartStdModal.show();
-            return;
-          }
+            if (!rates.length) {
+              stdChartInstance = new Chart(stdCtx, { type: 'bar', data: { labels: [], datasets: [] }, options: { responsive: false, maintainAspectRatio: false, elements: { point: { radius: 3, hoverRadius: 3 } } } });
+              document.getElementById('stddev-chart-summary').textContent = 'No data.';
+              chartStdModal.show();
+              return;
+            }
           const mean = data.mean;
           const stdev = data.stdev;
           const { config, rows } = createStdChartConfig(rates, mean, stdev, yMax);
           config.options = config.options || {};
           config.options.responsive = false;
           config.options.maintainAspectRatio = false;
+          config.options.elements = { point: { radius: 3, hoverRadius: 3 } };
           stdChartInstance = new Chart(stdCtx, config);
           const stdTable = document.getElementById('std-data-table');
           if (stdTable) {
@@ -551,12 +554,12 @@ window.addEventListener('DOMContentLoaded', () => {
         .then(data => {
           const rates = data.rates.map(r => r.rate).filter(r => r <= yMax);
           if (ngStdChartInstance) ngStdChartInstance.destroy();
-          if (!rates.length) {
-            ngStdChartInstance = new Chart(ngStdCtx, { type: 'bar', data: { labels: [], datasets: [] }, options: { responsive: false, maintainAspectRatio: false } });
-            document.getElementById('ng-stddev-chart-summary').textContent = 'No data.';
-            chartNgStdModal.show();
-            return;
-          }
+            if (!rates.length) {
+              ngStdChartInstance = new Chart(ngStdCtx, { type: 'bar', data: { labels: [], datasets: [] }, options: { responsive: false, maintainAspectRatio: false, elements: { point: { radius: 3, hoverRadius: 3 } } } });
+              document.getElementById('ng-stddev-chart-summary').textContent = 'No data.';
+              chartNgStdModal.show();
+              return;
+            }
           const mean = data.mean;
           const stdev = data.stdev;
           const { config, rows } = createStdChartConfig(rates, mean, stdev, yMax, {
@@ -565,10 +568,11 @@ window.addEventListener('DOMContentLoaded', () => {
             lineColor: 'rgba(153, 102, 255, 1)',
             decimals: 3
           });
-          config.options = config.options || {};
-          config.options.responsive = false;
-          config.options.maintainAspectRatio = false;
-          ngStdChartInstance = new Chart(ngStdCtx, config);
+            config.options = config.options || {};
+            config.options.responsive = false;
+            config.options.maintainAspectRatio = false;
+            config.options.elements = { point: { radius: 3, hoverRadius: 3 } };
+            ngStdChartInstance = new Chart(ngStdCtx, config);
           const ngStdTable = document.getElementById('ng-std-data-table');
           if (ngStdTable) {
             ngStdTable.innerHTML = '<thead><tr><th>Range</th><th>Count</th></tr></thead><tbody></tbody>';
@@ -701,12 +705,13 @@ window.addEventListener('DOMContentLoaded', () => {
               { label: 'NG PPM', data: data.ng_ppm, borderColor: 'red', fill: false }
             ]
           },
-          options: {
-            responsive: false,
-            maintainAspectRatio: false,
-            scales: { y: { beginAtZero: true } }
-          }
-        });
+            options: {
+              responsive: false,
+              maintainAspectRatio: false,
+              elements: { point: { radius: 3, hoverRadius: 3 } },
+              scales: { y: { beginAtZero: true } }
+            }
+          });
         if (table) {
           table.innerHTML = '<thead><tr><th>Period</th><th>Total Boards</th><th>FalseCall PPM</th><th>NG PPM</th></tr></thead><tbody></tbody>';
           const tbody = table.querySelector('tbody');


### PR DESCRIPTION
## Summary
- Ensure chart points retain a constant size by setting `elements.point.radius` and `hoverRadius` for all charts in `analysis.js`

## Testing
- `SECRET_KEY=testing pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af05fa51148325af38699f53c53758