### PR TITLE
Add CSV export controls to data tables

### DIFF
--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -241,7 +241,7 @@ window.addEventListener('DOMContentLoaded', () => {
         .join('');
       if (window.jQuery) {
         if ($.fn.DataTable.isDataTable(table)) $(table).DataTable().destroy();
-        $(table).DataTable();
+        $(table).DataTable({ paging: false });
       }
     }
   }
@@ -379,7 +379,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const table = document.querySelector(`#${basePath}-table table`);
   if (table && window.jQuery) {
-    $(table).DataTable();
+    $(table).DataTable({ paging: false });
   }
   if (table) {
     table.addEventListener('click', async e => {

--- a/static/js/aoi_fi_compare.js
+++ b/static/js/aoi_fi_compare.js
@@ -149,10 +149,10 @@
 
     // Initialize DataTables if the plugin is available
     if (window.jQuery && $.fn && $.fn.DataTable) {
-      const aoiTableEl = document.querySelector('.comparison-panels details:nth-of-type(1) table');
-      const fiTableEl = document.querySelector('.comparison-panels details:nth-of-type(2) table');
-      if (aoiTableEl) $(aoiTableEl).DataTable();
-      if (fiTableEl) $(fiTableEl).DataTable();
+      const aoiTableEl = document.getElementById('compare-aoi-table');
+      const fiTableEl = document.getElementById('compare-fi-table');
+      if (aoiTableEl) $(aoiTableEl).DataTable({ paging: false });
+      if (fiTableEl) $(fiTableEl).DataTable({ paging: false });
     }
 
     // Expose row data for future filtering

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -336,6 +336,7 @@
                 <thead></thead>
                 <tbody></tbody>
               </table>
+              <button type="button" onclick="exportTableToExcel('#sql-results','sql_results.csv')">Export CSV</button>
             </div>
           </div>
         </div>
@@ -346,6 +347,7 @@
               <canvas id="daily-report-canvas" style="display:none"></canvas>
             </div>
             <table id="daily-report-table" style="display:none"></table>
+            <button type="button" onclick="exportTableToExcel('#daily-report-table','daily_report.csv')">Export CSV</button>
             <label>Margin:
               <select id="daily-margin">
                 <option value="0.25">0.25"</option>
@@ -369,6 +371,7 @@
               <canvas id="weekly-report-canvas" style="display:none"></canvas>
             </div>
             <table id="weekly-report-table" style="display:none"></table>
+            <button type="button" onclick="exportTableToExcel('#weekly-report-table','weekly_report.csv')">Export CSV</button>
             <label>Margin:
               <select id="weekly-margin">
                 <option value="0.25">0.25"</option>
@@ -392,6 +395,7 @@
               <canvas id="monthly-report-canvas" style="display:none"></canvas>
             </div>
             <table id="monthly-report-table" style="display:none"></table>
+            <button type="button" onclick="exportTableToExcel('#monthly-report-table','monthly_report.csv')">Export CSV</button>
             <label>Margin:
               <select id="monthly-margin">
                 <option value="0.25">0.25"</option>
@@ -415,6 +419,7 @@
               <canvas id="yearly-report-canvas" style="display:none"></canvas>
             </div>
             <table id="yearly-report-table" style="display:none"></table>
+            <button type="button" onclick="exportTableToExcel('#yearly-report-table','yearly_report.csv')">Export CSV</button>
             <label>Margin:
               <select id="yearly-margin">
                 <option value="0.25">0.25"</option>
@@ -452,7 +457,7 @@
             <button type="button" class="model-filter-btn" data-filter="th">TH</button>
           </div>
         </div>
-        <table>
+        <table id="moat-data-table">
           <thead><tr>
             <th>Model Name</th><th>Total Boards</th><th>Total Parts/Board</th>
             <th>Total Parts</th><th>NG Parts</th><th>NG PPM</th>
@@ -475,6 +480,7 @@
           {% endfor %}
           </tbody>
         </table>
+        <button type="button" onclick="exportTableToExcel('#moat-data-table','moat.csv')">Export CSV</button>
       </div>
     </div>
 
@@ -507,6 +513,7 @@
             </div>
             <p id="fc-chart-summary" class="chart-summary"></p>
             <table id="fc-data-table"></table>
+            <button type="button" onclick="exportTableToExcel('#fc-data-table','fc_data.csv')">Export CSV</button>
             <label>Margin:
               <select id="fc-margin">
                 <option value="0.25">0.25"</option>
@@ -534,6 +541,7 @@
             </div>
             <p id="ng-chart-summary" class="chart-summary"></p>
             <table id="ng-data-table"></table>
+            <button type="button" onclick="exportTableToExcel('#ng-data-table','ng_data.csv')">Export CSV</button>
             <label>Margin:
               <select id="ng-margin">
                 <option value="0.25">0.25"</option>
@@ -560,6 +568,7 @@
             </div>
             <p id="stddev-chart-summary" class="chart-summary"></p>
             <table id="std-data-table"></table>
+            <button type="button" onclick="exportTableToExcel('#std-data-table','std_data.csv')">Export CSV</button>
             <label>Margin:
               <select id="std-margin">
                 <option value="0.25">0.25"</option>
@@ -586,6 +595,7 @@
             </div>
             <p id="ng-stddev-chart-summary" class="chart-summary"></p>
             <table id="ng-std-data-table"></table>
+            <button type="button" onclick="exportTableToExcel('#ng-std-data-table','ng_std_data.csv')">Export CSV</button>
             <label>Margin:
               <select id="ng-std-margin">
                 <option value="0.25">0.25"</option>

--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -200,6 +200,7 @@
                 {% endfor %}
               </tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#assemblyTable','assembly.csv')">Export CSV</button>
           </div>
         </div>
       </div>
@@ -231,6 +232,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#daily-table','daily.csv')">Export CSV</button>
           </div>
           <div id="weekly" class="subtab-content">
             <h2>Weekly Summary <button class="download-report" data-period="weekly">Download PDF</button></h2>
@@ -252,6 +254,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#weekly-table','weekly.csv')">Export CSV</button>
           </div>
           <div id="monthly" class="subtab-content">
             <h2>Monthly Summary <button class="download-report" data-period="monthly">Download PDF</button></h2>
@@ -273,6 +276,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#monthly-table','monthly.csv')">Export CSV</button>
           </div>
           <div id="yearly" class="subtab-content">
             <h2>Yearly Summary <button class="download-report" data-period="yearly">Download PDF</button></h2>
@@ -294,6 +298,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#yearly-table','yearly.csv')">Export CSV</button>
           </div>
         </div>
       </div>
@@ -315,12 +320,13 @@
               <thead></thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#sql-results','sql_results.csv')">Export CSV</button>
           </div>
         </div>
       </div>
     </div>
     <div id="aoi-table">
-      <table>
+      <table id="aoi-data-table">
         <thead>
           <tr>
             <th>Date</th>
@@ -358,6 +364,7 @@
           {% endfor %}
         </tbody>
       </table>
+      <button type="button" onclick="exportTableToExcel('#aoi-data-table','aoi_records.csv')">Export CSV</button>
     </div>
   </div>
 
@@ -377,6 +384,7 @@
             <thead></thead>
             <tbody></tbody>
           </table>
+          <button type="button" onclick="exportTableToExcel('#modal-table','modal_data.csv')">Export CSV</button>
         </div>
       </div>
     </div>

--- a/templates/compare_aoi_fi.html
+++ b/templates/compare_aoi_fi.html
@@ -7,6 +7,7 @@
   <script id="aoi-data" type="application/json">{{ aoi_rows|tojson }}</script>
   <script id="fi-data" type="application/json">{{ fi_rows|tojson }}</script>
   <script id="grade-data" type="application/json">{{ grades|tojson }}</script>
+  <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/tabs.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/chart_modal.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/aoi_fi_compare.js') }}" defer></script>
@@ -31,7 +32,7 @@
   <div class="comparison-panels" style="display:flex; gap:20px; flex-wrap:wrap; margin-top:20px;">
     <details class="panel" style="flex:1;" open>
       <summary>AOI Reports</summary>
-      <table>
+      <table id="compare-aoi-table">
         <thead>
           <tr>
             <th>Date</th>
@@ -63,10 +64,11 @@
           {% endfor %}
         </tbody>
       </table>
+      <button type="button" onclick="exportTableToExcel('#compare-aoi-table','aoi_reports.csv')">Export CSV</button>
     </details>
     <details class="panel" style="flex:1;" open>
       <summary>Final Inspect Reports</summary>
-      <table>
+      <table id="compare-fi-table">
         <thead>
           <tr>
             <th>Date</th>
@@ -98,6 +100,7 @@
           {% endfor %}
         </tbody>
       </table>
+      <button type="button" onclick="exportTableToExcel('#compare-fi-table','final_inspect_reports.csv')">Export CSV</button>
     </details>
   </div>
   <div class="modal fade" id="chart-modal" tabindex="-1" aria-hidden="true">
@@ -115,6 +118,7 @@
             <thead></thead>
             <tbody></tbody>
           </table>
+          <button type="button" onclick="exportTableToExcel('#modal-table','modal_data.csv')">Export CSV</button>
         </div>
       </div>
     </div>

--- a/templates/final_inspect.html
+++ b/templates/final_inspect.html
@@ -199,6 +199,7 @@
                 {% endfor %}
               </tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#assemblyTable','assembly.csv')">Export CSV</button>
           </div>
         </div>
       </div>
@@ -230,6 +231,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#daily-table','daily.csv')">Export CSV</button>
           </div>
           <div id="weekly" class="subtab-content">
             <h2>Weekly Summary <button class="download-report" data-period="weekly">Download PDF</button></h2>
@@ -251,6 +253,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#weekly-table','weekly.csv')">Export CSV</button>
           </div>
           <div id="monthly" class="subtab-content">
             <h2>Monthly Summary <button class="download-report" data-period="monthly">Download PDF</button></h2>
@@ -272,6 +275,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#monthly-table','monthly.csv')">Export CSV</button>
           </div>
           <div id="yearly" class="subtab-content">
             <h2>Yearly Summary <button class="download-report" data-period="yearly">Download PDF</button></h2>
@@ -293,6 +297,7 @@
               </thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#yearly-table','yearly.csv')">Export CSV</button>
           </div>
         </div>
       </div>
@@ -314,12 +319,13 @@
               <thead></thead>
               <tbody></tbody>
             </table>
+            <button type="button" onclick="exportTableToExcel('#sql-results','sql_results.csv')">Export CSV</button>
           </div>
         </div>
       </div>
     </div>
     <div id="final-inspect-table">
-      <table>
+      <table id="fi-data-table">
         <thead>
           <tr>
             <th>Date</th>
@@ -357,6 +363,7 @@
           {% endfor %}
         </tbody>
       </table>
+      <button type="button" onclick="exportTableToExcel('#fi-data-table','fi_records.csv')">Export CSV</button>
     </div>
   </div>
 
@@ -376,6 +383,7 @@
             <thead></thead>
             <tbody></tbody>
           </table>
+          <button type="button" onclick="exportTableToExcel('#modal-table','modal_data.csv')">Export CSV</button>
         </div>
       </div>
     </div>

--- a/templates/jobs.html
+++ b/templates/jobs.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% import 'components/forms.html' as forms %}
 {% block title %}Jobs Dashboard{% endblock %}
+{% block head_extra %}
+  <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
+{% endblock %}
 {% block content %}
   <h1>Jobs Dashboard</h1>
 
@@ -16,6 +19,7 @@
     </thead>
     <tbody></tbody>
   </table>
+  <button type="button" onclick="exportTableToExcel('#jobs-table','jobs.csv')">Export CSV</button>
 
   <form id="update-form" class="needs-validation" novalidate>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/templates/part_markings.html
+++ b/templates/part_markings.html
@@ -2,6 +2,7 @@
 {% import 'components/forms.html' as forms %}
 {% block title %}Verified Part Markings{% endblock %}
 {% block head_extra %}
+  <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
   <script src="/static/js/part_markings.js" defer></script>
 {% endblock %}
 {% block content %}
@@ -45,7 +46,7 @@
     </div>
     <div id="divider"></div>
     <div id="markings-table">
-      <table class="editable" data-update-url="/part-markings" data-fields="verified_markings,manufacturer,mfg_number2,mfg_number1,part_number">
+      <table id="part-markings-table" class="editable" data-update-url="/part-markings" data-fields="verified_markings,manufacturer,mfg_number2,mfg_number1,part_number">
         <thead>
           <tr>
             <th>Verified Markings</th>
@@ -73,6 +74,7 @@
           {% endfor %}
         </tbody>
       </table>
+      <button type="button" onclick="exportTableToExcel('#part-markings-table','part_markings.csv')">Export CSV</button>
     </div>
   </div>
 {% endblock %}

--- a/templates/rework.html
+++ b/templates/rework.html
@@ -2,6 +2,7 @@
 {% import 'components/forms.html' as forms %}
 {% block title %}Rework - Stencil Lookup{% endblock %}
 {% block head_extra %}
+  <script src="{{ url_for('static', filename='js/report_utils.js') }}" defer></script>
   <script src="/static/js/stencil_lookup.js" defer></script>
 {% endblock %}
 {% block content %}
@@ -33,7 +34,7 @@
     </div>
     <div id="divider"></div>
     <div id="stencil-table">
-      <table class="editable" data-update-url="/rework" data-fields="stencil_number,part_number,ref,description,location_of_stencil">
+      <table id="stencil-data-table" class="editable" data-update-url="/rework" data-fields="stencil_number,part_number,ref,description,location_of_stencil">
         <thead>
           <tr>
             <th>Stencil Number</th>
@@ -61,6 +62,7 @@
           {% endfor %}
         </tbody>
       </table>
+      <button type="button" onclick="exportTableToExcel('#stencil-data-table','stencil_lookup.csv')">Export CSV</button>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable table export button support across dashboard pages
- load `report_utils.js` on all table templates
- disable DataTables pagination to export complete datasets

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1262d3888325b552a2664f385e8c