### PR TITLE
feat: show average inspected per operator

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -244,6 +244,11 @@ table thead th {
   font-size: 0.9em;
 }
 
+.avg-operators {
+  color: var(--color-accent);
+  font-weight: bold;
+}
+
 @media (max-width: 600px) {
   .chart-widget {
     height: 200px;

--- a/static/js/aoi_dashboard.js
+++ b/static/js/aoi_dashboard.js
@@ -251,8 +251,9 @@ window.addEventListener('DOMContentLoaded', () => {
     if (!el) return;
     const data = buildOperatorsChartData();
     if (!data) { el.textContent = ''; return; }
+    const avgInspected = data.labels.length ? (data.totals.inspected / data.labels.length) : 0;
     const rate = data.totals.inspected ? (data.totals.rejected / data.totals.inspected * 100) : 0;
-    el.textContent = `Total inspected: ${data.totals.inspected}, Total rejected: ${data.totals.rejected}, Avg reject rate: ${rate.toFixed(2)}%`;
+    el.innerHTML = `Total inspected: ${data.totals.inspected}, Total rejected: ${data.totals.rejected}, Avg reject rate: ${rate.toFixed(2)}% <span class="avg-operators">Avg inspected/operator: ${avgInspected.toFixed(1)}</span>`;
   }
 
   function updateShiftDetails() {

--- a/static/js/generate_reports.js
+++ b/static/js/generate_reports.js
@@ -43,7 +43,16 @@ document.getElementById('generate-report')?.addEventListener('click', async () =
   const fcCtx = makeCanvas();
   const ngCtx = makeCanvas();
   const opCtx = makeCanvas();
+  const opDetails = document.createElement('div');
+  opDetails.className = 'chart-details';
+  content.appendChild(opDetails);
   const yieldCtx = makeCanvas();
+
+  const opTotalsInspected = aoiData.operators.reduce((sum, o) => sum + o.inspected, 0);
+  const opTotalsRejected = aoiData.operators.reduce((sum, o) => sum + o.rejected, 0);
+  const opAvgRejectRate = opTotalsInspected ? (opTotalsRejected / opTotalsInspected * 100) : 0;
+  const opAvgInspected = aoiData.operators.length ? (opTotalsInspected / aoiData.operators.length) : 0;
+  opDetails.innerHTML = `Total inspected: ${opTotalsInspected}, Total rejected: ${opTotalsRejected}, Avg reject rate: ${opAvgRejectRate.toFixed(2)}% <span class="avg-operators">Avg inspected/operator: ${opAvgInspected.toFixed(1)}</span>`;
 
   const table = document.createElement('table');
   content.appendChild(table);


### PR DESCRIPTION
## Summary
- display average inspected boards per operator on AOI dashboard
- highlight average figure with new style
- include average inspected/operator text in generated PDF reports

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c07fd3b5d483259bb938f767e9767e