### PR TITLE
Add FI reject rate column to AOI dashboard

### DIFF
--- a/templates/aoi.html
+++ b/templates/aoi.html
@@ -186,6 +186,7 @@
                   <th>Assembly</th>
                   <th>Inspected</th>
                   <th>Rejected</th>
+                  <th>FI Reject Rate</th>
                   <th>Yield</th>
                 </tr>
               </thead>
@@ -195,6 +196,13 @@
                   <td>{{ row['assembly'] }}</td>
                   <td>{{ row['inspected'] }}</td>
                   <td>{{ row['rejected'] }}</td>
+                  <td>
+                    {% if row.get('fi_reject_rate') is not none %}
+                    {{ '{:.2%}'.format(row.get('fi_reject_rate')) }}
+                    {% else %}
+                    <span class="text-muted">null</span>
+                    {% endif %}
+                  </td>
                   <td>{{ '{:.2%}'.format(row['yield']) }}</td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
## Summary
- show FI Reject Rate in AOI assembly performance table
- load reject rates via Supabase combined_reports view and display null when absent
- fetch updated assembly data on render to populate FI rates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c080d6f7948325a9befa41ce7802b0